### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix null order_ids in stg_orders

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -1,0 +1,7 @@
+models:
+  - name: stg_orders
+    columns:
+      - name: order_id
+        tests:
+          - not_null
+          - unique

--- a/models/staging/stg_orders.sql
+++ b/models/staging/stg_orders.sql
@@ -1,0 +1,7 @@
+SELECT
+  id AS order_id,
+  user_id AS customer_id,
+  order_date,
+  status
+FROM {{ source('jaffle_shop', 'raw_orders_validation') }}
+WHERE id IS NOT NULL  -- Add this line to filter out null IDs


### PR DESCRIPTION
This PR addresses the recent incident where null order_ids were detected in the stg_orders model.

Changes:
1. Updated stg_orders.sql to filter out rows with null IDs from the source table.
2. Added explicit not_null and unique tests for the order_id column in the schema.yml file.

These changes should prevent null order_ids from propagating through the data pipeline and add an additional layer of data quality checks.

Next steps:
1. Investigate the root cause of null IDs in the raw_orders_validation table.
2. Monitor the impact of this change on downstream models and reports.
3. Consider implementing additional data quality checks at the source level.

Please review and test these changes before merging.<br><br>Created by: `joost@elementary-data.com`