### PR TITLE
Maayan via Elementary: Fix syntax error in order_items model

### DIFF
--- a/models/order_items.sql
+++ b/models/order_items.sql
@@ -1,0 +1,7 @@
+-- depends_on: ELEMENTARY_TESTS.jaffle_shop.orders
+
+
+  
+  
+    select * from ELEMENTARY_TESTS.jaffle_shop.orders
+  


### PR DESCRIPTION
This PR fixes a syntax error in the order_items model. The typo 'fromm' has been corrected to 'from' in the SQL query.<br><br>Created by: `maayan+172@elementary-data.com`