### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix order_items model: Remove randomization causing not_null test failures

### DIFF
--- a/jaffle_shop_online/models/order_items.sql
+++ b/jaffle_shop_online/models/order_items.sql
@@ -1,10 +1,3 @@
 -- depends_on: {{ ref('orders') }}
 
-{% if execute %}
-  {% set random_bool = run_query('select random() % 2 = 0')[0].values()[0] %}
-  {% if random_bool %}
-    select * fromm {{ ref('orders') }}
-  {% else %}
-    select * from {{ ref('orders') }}
-  {% endif %}
-{% endif %}
+select * from {{ ref('orders') }}


### PR DESCRIPTION
This PR addresses the intermittent failures of the `not_null` test on the `order_items` model. The issue was caused by a deliberate error in the model that randomly chose between a correct SQL statement and one with a typo.

Changes made:
1. Removed the randomization logic.
2. Kept only the correct SQL statement.

This change should resolve the `not_null` test failures for the `order_id` column in the `order_items` model.<br><br>Created by: `joost@elementary-data.com`