### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix typo in order_items.sql

### DIFF
--- a/jaffle_shop_online/models/order_items.sql
+++ b/jaffle_shop_online/models/order_items.sql
@@ -3,7 +3,7 @@
 {% if execute %}
   {% set random_bool = run_query('select random() % 2 = 0')[0].values()[0] %}
   {% if random_bool %}
-    select * fromm {{ ref('orders') }}
+    select * from {{ ref('orders') }}
   {% else %}
     select * from {{ ref('orders') }}
   {% endif %}


### PR DESCRIPTION
This PR fixes a typo in the order_items.sql file that was causing a syntax error.

Changes made:
- Corrected 'fromm' to 'from' in the SQL query.

This fix should resolve the critical incident and allow the order_items model to compile and run successfully.<br><br>Created by: `joost@elementary-data.com`