### PR TITLE
Maayan via Elementary: Fix typo in order_items.sql

### DIFF
--- a/jaffle_shop_online/models/order_items.sql
+++ b/jaffle_shop_online/models/order_items.sql
@@ -3,7 +3,7 @@
 {% if execute %}
   {% set random_bool = run_query('select random() % 2 = 0')[0].values()[0] %}
   {% if random_bool %}
-    select * fromm {{ ref('orders') }}
+    select * from {{ ref('orders') }}
   {% else %}
     select * from {{ ref('orders') }}
   {% endif %}


### PR DESCRIPTION
This PR fixes a syntax error in the order_items.sql file. The typo 'fromm' has been corrected to 'from' to resolve the SQL compilation error that was causing the model to fail intermittently.<br><br>Created by: `maayan+172@elementary-data.com`