### PR TITLE
Maayan via Elementary: Fix syntax error in order_items model

### DIFF
--- a/models/order_items.sql
+++ b/models/order_items.sql
@@ -1,0 +1,7 @@
+-- depends_on: ELEMENTARY_TESTS.jaffle_shop.orders
+
+
+  
+  
+    select * from ELEMENTARY_TESTS.jaffle_shop.orders
+  


### PR DESCRIPTION
This PR fixes the syntax error in the order_items model by removing the random error introduction and simplifying the query to always use the correct syntax.

Changes:
- Removed the Jinja templating that randomly introduced a syntax error
- Simplified the query to always select from the 'orders' model using correct SQL syntax

This fix should resolve the CRITICAL incident affecting the order_items model and prevent future occurrences of this error.<br><br>Created by: `maayan+172@elementary-data.com`