### PR TITLE
Maayan via Elementary: Fix syntax error in order_items model

### DIFF
--- a/jaffle_shop_online/models/order_items.sql
+++ b/jaffle_shop_online/models/order_items.sql
@@ -1,10 +1,3 @@
 -- depends_on: {{ ref('orders') }}
 
-{% if execute %}
-  {% set random_bool = run_query('select random() % 2 = 0')[0].values()[0] %}
-  {% if random_bool %}
-    select * fromm {{ ref('orders') }}
-  {% else %}
-    select * from {{ ref('orders') }}
-  {% endif %}
-{% endif %}
+select * from {{ ref('orders') }}


### PR DESCRIPTION
This PR fixes a critical issue in the order_items model where a random syntax error was being introduced.

Changes:
- Removed the Jinja template that was randomly introducing a syntax error
- Simplified the model to always use the correct SQL syntax

This change should resolve the CRITICAL incident reported for the order_items model.<br><br>Created by: `maayan+172@elementary-data.com`