### PR TITLE
Maayan via Elementary: Add tests for agg_sessions model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -221,6 +221,34 @@ models:
       - name: platform
         data_type: varchar
         description: "Platform where the session was made. For example, website, iOS app, Android app, etc."
+    tests:
+      - unique:
+          column_name: session_id
+      - dbt_utils.expression_is_true:
+          expression: "started_at <= ended_at"
+          config:
+            severity: error
+      - dbt_utils.expression_is_true:
+          expression: "datediff('second', started_at, ended_at) >= 0"
+      - dbt_utils.expression_is_true:
+          expression: "ad_id IS NULL OR utm_source IS NOT NULL"
+      - dbt_utils.recency:
+          datepart: hour
+          field: started_at
+          interval: 24
+    columns:
+      - name: customer_id
+        tests:
+          - not_null
+      - name: platform
+        tests:
+          - accepted_values:
+              values: ['app', 'website']
+      - name: ad_id
+        tests:
+          - relationships:
+              to: ref('marketing_ads')
+              field: ad_id
 
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"


### PR DESCRIPTION
This PR adds a set of high-quality, impactful dbt tests for the `agg_sessions` model. These tests will help ensure data quality, consistency, and reliability for this critical marketing data model.

The following tests have been added:

1. Unique session_id
2. Not null customer_id
3. Valid timestamp range for started_at and ended_at
4. Valid platform values
5. Referential integrity with marketing_ads
6. Non-negative session duration
7. Consistent UTM source
8. Recent data freshness

These tests cover various aspects of data quality, including uniqueness, referential integrity, data consistency, and freshness. They will help maintain the reliability and accuracy of the aggregated session data, which is crucial for marketing analysis and customer behavior tracking.<br><br>Created by: `maayan+172@elementary-data.com`