### PR TITLE
Mika via Elementary: Add not_null test for order_id in stg_orders model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -29,6 +29,9 @@ models:
           - unique:
               config:
                 severity: warn
+          - not_null:
+              config:
+                severity: error
       - name: status
         tests:
           - accepted_values:


### PR DESCRIPTION
This PR adds an explicit not_null test for the order_id column in the stg_orders model. This will help catch any potential NULL values in this critical field and improve data quality checks.<br><br>Created by: `mika+demo@elementary-data.com`