### PR TITLE
Mika via Elementary: Fix typo in ads_spend.sql: utm_campain to utm_campaign

### DIFF
--- a/jaffle_shop_online/models/marketing/ads_spend.sql
+++ b/jaffle_shop_online/models/marketing/ads_spend.sql
@@ -9,6 +9,6 @@ with marketing_ads as (
     from {{ ref("marketing_ads") }}
 )
 
-select date as date_day, utm_source, utm_medium, utm_campain, sum(cost) as spend
+select date as date_day, utm_source, utm_medium, utm_campaign, sum(cost) as spend
 from marketing_ads
-group by date, utm_source, utm_medium, utm_campain
+group by date, utm_source, utm_medium, utm_campaign


### PR DESCRIPTION
This PR fixes a typo in the `ads_spend.sql` file where 'utm_campain' was misspelled. This typo was causing schema change issues in downstream models, particularly in `cpa_and_roas`.

Changes made:
- Corrected 'utm_campain' to 'utm_campaign' in the SELECT statement
- Updated the GROUP BY clause to use the correct column name

This change should resolve the schema change issues detected by the `schema_changes_from_baseline` test on the `cpa_and_roas` model.

Please review and test thoroughly before merging, as this change might affect existing queries or reports using the misspelled column name.<br><br>Created by: `mika+demo@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the campaign column name to ensure accurate reporting and aggregation of ad spend data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->