### PR TITLE
Elementary: Upgrade dbt package.

### DIFF
--- a/jaffle_shop_online/packages.yml
+++ b/jaffle_shop_online/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: elementary-data/elementary
-    version: 0.19.0
+    version: 0.20.1
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - package: calogica/dbt_expectations


### PR DESCRIPTION

**Elementary**: This PR upgrades Elementary's dbt package version to the latest.
We recommend upgrading in order to enjoy the latest features, performance improvements, and bug fixes.
You can view the release notes [here](https://github.com/elementary-data/dbt-data-reliability/releases).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the version of the elementary-data package to 0.19.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->