### PR TITLE
Michael Myaskovsky via Elementary: Update ownership of upstream tables for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Ella"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Ella"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR updates the ownership of the upstream tables for 'cpa_and_roas' from 'Ella' to '@marketing-team'. The following changes were made:

1. Changed the owner of 'ads_spend' from 'Ella' to '@marketing-team'
2. Changed the owner of 'attribution_touches' from 'Ella' to '@marketing-team'

This change will ensure that the @marketing-team is notified of any alerts related to these tables, especially when team members are on vacation.<br><br>Created by: `michael@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ownership information for certain marketing data models to reflect the current team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->