### PR TITLE
Michael Myaskovsky via Elementary: Update marketing models ownership

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Ella"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Ella"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR updates the ownership of the `ads_spend` and `attribution_touches` models from "Ella" to "@marketing-team". This change ensures that the marketing team will be notified of any incidents related to these models, even when individual team members are on vacation.<br><br>Created by: `michael@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated model ownership metadata to reflect the marketing team as the owner of relevant models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->