### PR TITLE
Michael Myaskovsky via Elementary: Fix intermittent SQL syntax error in order_items model

### DIFF
--- a/jaffle_shop_online/models/order_items.sql
+++ b/jaffle_shop_online/models/order_items.sql
@@ -1,10 +1,3 @@
 -- depends_on: {{ ref('orders') }}
 
-{% if execute %}
-  {% set random_bool = run_query('select random() % 2 = 0')[0].values()[0] %}
-  {% if random_bool %}
-    select * fromm {{ ref('orders') }}
-  {% else %}
-    select * from {{ ref('orders') }}
-  {% endif %}
-{% endif %}
+select * from {{ ref('orders') }}


### PR DESCRIPTION
This PR fixes the intermittent SQL syntax error in the `order_items` model by removing the Jinja templating that was randomly introducing a typo.

Changes made:
1. Removed the Jinja templating that was randomly selecting between correct and incorrect SQL syntax.
2. Simplified the model to always use the correct SQL syntax.

This change will resolve the CRITICAL incident (ID: 7b8feefc-94ff-4fba-a3ee-c9246d8b17df) that was causing model failures.

After merging this PR, please re-run the `order_items` model to verify the fix.<br><br>Created by: `michael@elementary-data.com`