### PR TITLE
Maayan via Elementary: Fix schema change in attribution_touches model

### DIFF
--- a/jaffle_shop_online/models/staging/stg_orders.sql
+++ b/jaffle_shop_online/models/staging/stg_orders.sql
@@ -16,7 +16,7 @@ renamed as (
     select
         id as order_id,
         user_id as customer_id,
-        order_date,
+        try_cast(order_date as timestamp) as order_date,  -- Added cast to timestamp
         status
 
     from source


### PR DESCRIPTION
This PR addresses a HIGH severity incident where the schema of the `attribution_touches` model changed unexpectedly. The root cause was traced to the `order_date` column in the `stg_orders` model, which was being passed as a STRING instead of a TIMESTAMP.

Changes:
- Modified `stg_orders.sql` to cast `order_date` to TIMESTAMP using `try_cast`.

This change should resolve the schema change issue in the `attribution_touches` model and restore the correct data type for the `converted_at` column.

Testing:
- Please run dbt tests to ensure this change resolves the schema change issue.
- Verify that the `attribution_touches` model compiles successfully with the `converted_at` column as a TIMESTAMP.

Reviewers: Please check if this change aligns with our data modeling standards and if there are any potential side effects in downstream models.<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of order dates to ensure they are consistently recognized as timestamps. This enhances reliability when viewing or analyzing order data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->