### PR TITLE
Michael Myaskovsky via Elementary: Update marketing model owners

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Ella"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Ella"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR updates the ownership of the `ads_spend` and `attribution_touches` models from 'Ella' to '@marketing-team'. This change ensures that the marketing team receives alerts for these models, even when individual team members are on vacation.

Changes made:
- Updated `jaffle_shop_online/models/marketing/schema.yml`:
  - Changed owner of `ads_spend` from 'Ella' to '@marketing-team'
  - Changed owner of `attribution_touches` from 'Ella' to '@marketing-team'

Please review these changes and approve if they align with the team's expectations for model ownership and alerting.<br><br>Created by: `michael@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ownership information for certain models to reflect the marketing team as the new owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->