### PR TITLE
Michael Myaskovsky via Elementary: Add Human as subscriber to cpa_and_roas table

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per month"
     meta:
       owner: "Ella"
+      subscribers: ["Human"]
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds Human as a subscriber to the cpa_and_roas table in the marketing schema. This will ensure that Human is notified when issues related to this table are resolved.<br><br>Created by: `michael@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model metadata to include a new subscribers field for improved tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->