### PR TITLE
Michael Myaskovsky via Elementary: Add marketing team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per month"
     meta:
       owner: "Noa"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This will ensure that the team is notified when issues related to this model are resolved.<br><br>Created by: `michael@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new metadata field to improve team visibility for the cpa_and_roas model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->