### PR TITLE
Nimrod via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -76,6 +76,8 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tests:
+          - unique
 
       - name: customer_id
         description: Foreign key to the customers table
@@ -116,6 +118,7 @@ models:
               column_anomalies:
                 - zero_count
                 - zero_percent
+                - average
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
@@ -318,6 +321,10 @@ models:
         description: '{{ doc("orders_status") }}'
       - name: amount
         description: "Total order amount (AUD) – already converted to dollars"
+        tests:
+          - accepted_range:
+              min_value: 0
+              max_value: 10000
       - name: credit_card_amount
         description: "Portion of the order paid with credit card (AUD)"
       - name: coupon_amount

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
This PR adds recommended upstream tests for the cpa_and_roas model. The following changes have been made:

1. For the `orders` model:
   - Added a unique test on the `order_id` column
   - Added a column_anomaly test on the `amount` column to check for average

2. For the `real_time_orders` model:
   - Added an accepted_range test for the `amount` field

3. For the `stg_orders` model:
   - Added volume_anomalies and freshness_anomalies tests

4. For the `stg_payments` model:
   - Added volume_anomalies and freshness_anomalies tests

These tests will help ensure data quality and consistency in the upstream models that feed into cpa_and_roas.<br><br>Created by: `nimrod+demo@elementary-data.com`