### PR TITLE
Mika via Elementary: Fix historical orders amount inconsistency

### DIFF
--- a/jaffle_shop_online/jaffle_shop_online/models/staging/historical_orders.sql
+++ b/jaffle_shop_online/jaffle_shop_online/models/staging/historical_orders.sql
@@ -1,0 +1,43 @@
+
+
+with orders as (
+    select * from ELEMENTARY_TESTS.mika_jaffle_shop_online.stg_orders
+),
+
+payments as (
+    select * from ELEMENTARY_TESTS.mika_jaffle_shop_online.stg_payments
+),
+
+order_payments as (
+    select
+        order_id,
+        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,
+        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,
+        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,
+        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,
+        sum(amount) as total_amount
+    from payments
+    group by order_id
+),
+
+final as (
+    select
+        o.order_id,
+        o.customer_id,
+        o.order_date,
+        o.status,
+        (op.credit_card_amount / 100)::numeric(16, 2) as credit_card_amount,
+        (op.coupon_amount / 100)::numeric(16, 2) as coupon_amount,
+        (op.bank_transfer_amount / 100)::numeric(16, 2) as bank_transfer_amount,
+        (op.gift_card_amount / 100)::numeric(16, 2) as gift_card_amount,
+        (op.total_amount / 100)::numeric(16, 2) as amount
+    from orders o
+    left join order_payments op on o.order_id = op.order_id
+)
+
+select *
+from final
+where date(order_date) < (
+    select date(max(order_date))
+    from final
+)


### PR DESCRIPTION
This PR addresses the root cause of the anomaly detected in the `RETURN_ON_ADVERTISING_SPEND` metric. The issue was caused by an inconsistency in the `amount` column between historical and real-time order data.

Changes made:
1. Modified the `historical_orders` model to convert amounts from cents to dollars.
2. Ensured consistency with the `real_time_orders` model.

This change will resolve the 100x difference in revenue calculations for the most recent day compared to historical data, fixing the anomaly detection test failure.

Steps to verify the fix:
1. Run the `historical_orders` model.
2. Run the `orders` model (which combines historical and real-time data).
3. Run the `cpa_and_roas` model.
4. Check that the `RETURN_ON_ADVERTISING_SPEND` anomaly test passes.

Additional recommendations:
1. Add a data quality test to ensure consistency in the `amount` column across all order data.
2. Review other models that may be affected by this change and update them if necessary.

Please review and test these changes before merging.<br><br>Created by: `mika+demo@elementary-data.com`