### PR TITLE
Mika via Elementary: Fix unit mismatch between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount -- Amount in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/tests/assert_historical_real_time_orders_amount_consistency.sql
+++ b/jaffle_shop_online/tests/assert_historical_real_time_orders_amount_consistency.sql
@@ -1,0 +1,22 @@
+-- Compare the average amount between historical and real-time orders
+-- to ensure they are within a reasonable range of each other
+with historical_avg as (
+    select avg(amount) as avg_amount
+    from {{ ref('historical_orders') }}
+    where date(order_date) = (
+        select date(max(order_date)) - interval 1 day
+        from {{ ref('historical_orders') }}
+    )
+),
+real_time_avg as (
+    select avg(amount) as avg_amount
+    from {{ ref('real_time_orders') }}
+)
+select
+    case
+        when abs(historical_avg.avg_amount - real_time_avg.avg_amount) / greatest(historical_avg.avg_amount, real_time_avg.avg_amount) > 0.1
+        then 'Average amounts differ by more than 10%'
+        else 'OK'
+    end as amount_consistency_check
+from historical_avg, real_time_avg
+having amount_consistency_check != 'OK'


### PR DESCRIPTION
This PR addresses the root cause of the ROAS anomaly by fixing the unit mismatch between historical and real-time orders.

Changes:
1. Updated the `historical_orders` model to convert the amount from cents to dollars.
2. Added a comment to indicate that all amount fields are now in dollars.
3. Updated the conversion for individual payment method amounts.

This change ensures consistency in the `amount` column across both historical and real-time orders, which should resolve the ROAS anomaly in the `cpa_and_roas` model.

Next steps:
1. Review and merge this PR.
2. Monitor the ROAS anomaly test to confirm the issue is resolved.
3. Consider adding a data quality test to verify that the `amount` column in the `orders` model is within an expected range for dollar values.

Please review the changes and let me know if any further modifications are needed.<br><br>Created by: `mika+demo@elementary-data.com`