### PR TITLE
Mika via Elementary: Fix: Normalize historical orders amount to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/tests/assert_historical_realtime_orders_consistent.sql
+++ b/jaffle_shop_online/tests/assert_historical_realtime_orders_consistent.sql
@@ -1,0 +1,36 @@
+-- tests/assert_historical_realtime_orders_consistent.sql
+with historical_orders as (
+    select * from {{ ref('historical_orders') }}
+    where date(order_date) = (
+        select date(max(order_date)) - interval 1 day
+        from {{ ref('historical_orders') }}
+    )
+),
+
+real_time_orders as (
+    select * from {{ ref('real_time_orders') }}
+    where date(order_date) = (
+        select date(max(order_date)) - interval 1 day
+        from {{ ref('real_time_orders') }}
+    )
+),
+
+compare_amounts as (
+    select
+        'historical' as source,
+        avg(amount) as avg_amount,
+        count(*) as order_count
+    from historical_orders
+
+    union all
+
+    select
+        'real_time' as source,
+        avg(amount) as avg_amount,
+        count(*) as order_count
+    from real_time_orders
+)
+
+select *
+from compare_amounts
+having count(distinct avg_amount) > 1 or count(distinct order_count) > 1


### PR DESCRIPTION
This PR addresses the data normalization issue between historical_orders and real_time_orders models, which was causing an anomaly in the RETURN_ON_ADVERTISING_SPEND metric.

Changes made:
1. Modified the historical_orders model to convert amounts from cents to dollars using the cents_to_dollars macro.
2. Added a new test to ensure consistency between historical and real-time order amounts.

These changes should resolve the 100x difference in the calculated ROAS and prevent similar issues in the future.<br><br>Created by: `mika+demo@elementary-data.com`