### PR TITLE
Michael Myaskovsky via Elementary: Add volume and freshness anomaly tests for stg_orders and stg_payments

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
This PR adds volume anomaly and freshness anomaly tests for the stg_orders and stg_payments models as per the recommendations for upstream tests of the cpa_and_roas model.<br><br>Created by: `michael@elementary-data.com`