### PR TITLE
Maayan via Elementary: Update ownership of marketing models to @marketing-team

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Noa"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Noa"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -118,7 +118,7 @@ models:
   - name: cpa_and_roas
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
-      owner: "Noa"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -263,7 +263,7 @@ models:
   - name: sessions
     description: "This table contains information on the sessions of all the customers and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Noa"
+      owner: "@marketing-team"
     config:
         tags: ["marketing", "pii"]
         elementary:


### PR DESCRIPTION
This PR updates the ownership of the following models from Noa to @marketing-team:

1. cpa_and_roas
2. sessions
3. attribution_touches
4. ads_spend

This change ensures that the marketing team will receive alerts for these models even when individual team members are on vacation.<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership information for several marketing models to reflect the current team responsible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->