### PR TITLE
Maayan via Elementary: Update ownership of upstream marketing models

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Noa"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Noa"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -263,7 +263,7 @@ models:
   - name: sessions
     description: "This table contains information on the sessions of all the customers and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Noa"
+      owner: "@marketing-team"
     config:
         tags: ["marketing", "pii"]
         elementary:


### PR DESCRIPTION
This PR updates the ownership of the upstream marketing models (ads_spend, attribution_touches, and sessions) from "Noa" to "@marketing-team". This change ensures that the marketing team will be notified of any alerts or incidents related to these models, even when individual team members are on vacation.

Changes made:
1. ads_spend: Changed owner from "Noa" to "@marketing-team"
2. attribution_touches: Changed owner from "Noa" to "@marketing-team"
3. sessions: Changed owner from "Noa" to "@marketing-team"

These changes will help maintain consistent alerting and ownership for the marketing data models.<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the listed owner for several marketing models to reflect the marketing team as the new point of contact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->