### PR TITLE
Michael Myaskovsky via Elementary: Add marketing team as subscriber for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Noa"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber for the cpa_and_roas model. This will ensure that the marketing team is notified about any significant changes or issues with this asset.

Changes made:
- Added `subscribers: "@marketing_team"` to the meta section of the cpa_and_roas model in the models/marketing/schema.yml file.

This change will help keep the marketing team informed about the performance and health of the cpa_and_roas model, which is crucial for monitoring marketing campaign effectiveness and return on ad spend.<br><br>Created by: `michael@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model metadata to include the marketing team as subscribers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->