### PR TITLE
Mika via Elementary: Fix unit mismatch between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +32,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
@@ -42,4 +44,4 @@ from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -50,4 +52,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+)


### PR DESCRIPTION
This PR addresses the root cause of the anomaly in the `RETURN_ON_ADVERTISING_SPEND` calculation by fixing a unit mismatch between historical and real-time order data.

Changes:
1. Updated `historical_orders` model to convert amounts from cents to dollars.
2. Added comments in both `historical_orders` and `real_time_orders` models to clearly indicate that all monetary amounts are in dollars.

These changes ensure consistency in the unit of measurement for the `amount` across both historical and real-time order data, which should resolve the anomaly in the `RETURN_ON_ADVERTISING_SPEND` calculation.

Additional steps to consider:
1. Update any downstream models that might have been compensating for this discrepancy.
2. Add a data quality test to ensure that the maximum daily total amount in both historical and real-time orders is within a reasonable range (e.g., between $100 and $1,000,000) to catch any future unit mismatches.

Please review and test these changes before merging.<br><br>Created by: `mika+demo@elementary-data.com`