### PR TITLE
Elon Demo via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -76,6 +76,8 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tests:
+          - unique
 
       - name: customer_id
         description: Foreign key to the customers table
@@ -116,6 +118,7 @@ models:
               column_anomalies:
                 - zero_count
                 - zero_percent
+                - average
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
@@ -307,6 +310,10 @@ models:
       tags: ["finance", "sales", "real_time"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - dbt_expectations.expect_column_values_to_be_between:
+          column_name: amount
+          max_value: '{{ max_price_from_raw_products() }}'  # This assumes you have a macro to get the max price
     columns:
       - name: order_id
         description: "Unique identifier for an order"

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,10 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies:
+          timestamp_column: order_date
     columns:
       - name: order_id
         tests:
@@ -46,6 +50,9 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
This PR adds recommended upstream tests for the cpa_and_roas model:

1. orders:
   - Added unique test on order_id
   - Added column anomaly test on amount (average)

2. real_time_orders:
   - Added test to validate that amount is <= max price from raw_products

3. stg_orders:
   - Added volume anomalies test
   - Added freshness anomalies test

4. stg_payments:
   - Added volume anomalies test
   - Added freshness anomalies test

These tests will help ensure data quality and consistency for the cpa_and_roas model and its upstream dependencies.<br><br>Created by: `elon+demo@elementary-data.com`