### PR TITLE
Mika via Elementary: Fix order amount unit mismatch

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -42,7 +42,7 @@ select
     customer_id,
     order_date,
     status,
-    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('amount_cents') }} as amount, -- Amount is now in dollars
     {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
     {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
     {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,


### PR DESCRIPTION
This PR addresses the root cause of the anomaly detected in the `RETURN_ON_ADVERTISING_SPEND` column of the `cpa_and_roas` model. The issue was caused by a unit mismatch between historical and real-time order data.

Changes made:
1. Updated `historical_orders` model to convert the amount from cents to dollars using the `cents_to_dollars` macro.
2. Added comments in both `historical_orders` and `real_time_orders` models to clearly indicate that the `amount` is in dollars.

These changes ensure consistent units (dollars) across both historical and real-time data, which should resolve the anomaly in the `RETURN_ON_ADVERTISING_SPEND` calculation.

Additional steps to consider after merging:
1. Update any downstream models that might be assuming the amount is in cents to handle the new dollar values correctly.
2. Add a data quality test to ensure that the `amount` values fall within an expected range for dollar amounts.

Please review these changes and test thoroughly before merging.<br><br>Created by: `mika+demo@elementary-data.com`