### PR TITLE
Elon Demo via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/jaffle_shop_online/models/schema.yml
@@ -1,0 +1,29 @@
+version: 2
+
+models:
+  - name: orders
+    tests:
+      - unique:
+          column_name: order_id  # Assuming 'order_id' is the primary key
+    columns:
+      - name: amount
+        tests:
+          - elementary.column_anomalies:
+              anomaly_direction: both
+              column_anomalies:
+                - average
+              time_bucket:
+                period: day
+                count: 1
+
+  - name: real_time_orders
+    tests:
+      - elementary.custom_sql:
+          sql: >
+            SELECT *
+            FROM {{ model }}
+            WHERE amount > (SELECT MAX(price) FROM {{ source('raw', 'products') }})
+          warn_if: '>0'
+          error_if: '>0'
+          severity: error
+          description: Validates that the amount field is less than or equal to the max price from the raw_products table

--- a/jaffle_shop_online/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/jaffle_shop_online/models/staging/schema.yml
@@ -1,0 +1,12 @@
+version: 2
+
+models:
+  - name: stg_orders
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
+
+  - name: stg_payments
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies


### PR DESCRIPTION
This PR adds upstream tests for the cpa_and_roas model as requested. The changes include:

1. For the `orders` model:
   - Added a unique test on the primary key (assumed to be `order_id`)
   - Added a column anomaly test on the `amount` column

2. For the `real_time_orders` model:
   - Added a custom SQL test to validate that the `amount` field is less than or equal to the max price from the raw_products table

3. For the `stg_orders` and `stg_payments` models:
   - Added volume anomaly tests
   - Added freshness anomaly tests

These tests will help ensure data quality and reliability for the upstream models feeding into cpa_and_roas.

Please review the changes and let me know if any adjustments are needed.<br><br>Created by: `elon+demo@elementary-data.com`