### PR TITLE
Mika via Elementary: Fix unit mismatch between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
This PR addresses the root cause of the anomaly detected in the `RETURN_ON_ADVERTISING_SPEND` calculation. The issue was caused by a unit mismatch between the `historical_orders` and `real_time_orders` models.

Changes made:
1. Updated the `historical_orders` model to convert amounts from cents to dollars, ensuring consistency with the `real_time_orders` model.
2. Added a comment in the `historical_orders` model to clarify the unit conversion.

Impact:
- This fix will correct the ROAS calculations for historical data, which were previously overestimated by a factor of 100.
- It will lead to more accurate marketing performance analysis and better allocation of marketing budgets.

Next steps after merging:
1. Run full dbt tests to ensure the change resolves the anomaly without introducing new issues.
2. Update any dashboards or reports that rely on this data to reflect the corrected ROAS values.
3. Consider adding more robust data quality checks to catch similar unit mismatches in the future.

Please review the changes and test thoroughly before merging.<br><br>Created by: `mika+demo@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all monetary amounts to be displayed in dollars instead of cents.
  * Added comments to clarify that all monetary values are now expressed in dollars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->