### PR TITLE
Mika via Elementary: Fix historical orders amount unit mismatch

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,14 +32,26 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+-- Convert cents to dollars for consistency with real_time_orders
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)
+
+-- Note: All amounts are now in dollars


### PR DESCRIPTION
This PR addresses a critical issue where the `amount` in the `historical_orders` model was in cents, while in the `real_time_orders` model it was in dollars. This inconsistency was causing anomalies in the `RETURN_ON_ADVERTISING_SPEND` calculation and other downstream metrics.

Changes made:
1. Modified the `historical_orders` model to convert cents to dollars using the `cents_to_dollars` macro.
2. Updated all payment method amounts to use the `cents_to_dollars` conversion.
3. Added a comment to clarify that all amounts are now in dollars.

This change ensures consistency between historical and real-time order data, which will resolve the ROAS calculation anomalies and improve the accuracy of all financial metrics derived from this data.

Next steps after merging:
1. Verify that the ROAS calculations in the `cpa_and_roas` model are now consistent across historical and real-time data.
2. Update any downstream models or reports that might have been compensating for this discrepancy.
3. Consider adding data tests to ensure that order amounts are within a reasonable dollar range.
4. Monitor the Elementary anomaly detection tests for the next few days to ensure the issue is resolved.

Please review and test these changes thoroughly before merging.<br><br>Created by: `mika+demo@elementary-data.com`