### PR TITLE
Nimrod via Elementary: Fix ROAS calculation unit mismatch

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -42,7 +42,8 @@ select
     customer_id,
     order_date,
     status,
-    {{ cents_to_dollars('amount_cents') }} as amount,
+    -- All monetary amounts in this model are in dollars
+    {{ cents_to_dollars('amount_cents') }} as amount,  -- Amount is now in dollars
     {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
     {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
     {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,


### PR DESCRIPTION
This PR addresses the root cause of the anomaly in the RETURN_ON_ADVERTISING_SPEND column by fixing a unit mismatch between historical and real-time order data.

Changes:
1. Updated `historical_orders.sql` to convert cents to dollars for all monetary amounts.
2. Added a clarifying comment in `real_time_orders.sql` to indicate that all monetary amounts are in dollars.

These changes ensure consistent units across both historical and real-time data, which should resolve the 100x difference in the ROAS calculation when comparing historical data to recent data.

After merging this PR, please re-run the dbt models and tests to verify that the ROAS calculations are now consistent across historical and real-time data.<br><br>Created by: `nimrod+demo@elementary-data.com`