### PR TITLE
Nimrod via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/jaffle_shop_online/models/schema.yml
@@ -1,0 +1,30 @@
+models:
+  - name: orders
+    columns:
+      - name: order_id  # Assuming 'order_id' is the primary key
+        tests:
+          - unique
+    tests:
+      - elementary.column_anomalies:
+          column_name: amount
+          anomaly_sensitivity: 2
+          anomaly_direction: both
+          timestamp_column: order_date  # Assuming there's an 'order_date' column
+          time_bucket:
+            period: day
+            count: 1
+          detection_period:
+            period: day
+            count: 14
+          column_anomalies:
+            - average
+
+  - name: real_time_orders
+    tests:
+      - relationships:
+          name: amount_validation
+          sql: >
+            select amount, max_price
+            from {{ model }}
+            left join {{ source('raw', 'products') }} on {{ model }}.product_id = raw_products.id
+            where amount > max_price

--- a/jaffle_shop_online/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/jaffle_shop_online/models/staging/schema.yml
@@ -1,0 +1,44 @@
+models:
+  - name: stg_orders
+    tests:
+      - elementary.volume_anomalies:
+          anomaly_sensitivity: 2
+          anomaly_direction: both
+          timestamp_column: created_at  # Assuming there's a 'created_at' column
+          time_bucket:
+            period: day
+            count: 1
+          detection_period:
+            period: day
+            count: 14
+      - elementary.freshness_anomalies:
+          anomaly_sensitivity: 2
+          timestamp_column: created_at
+          time_bucket:
+            period: day
+            count: 1
+          detection_period:
+            period: day
+            count: 14
+
+  - name: stg_payments
+    tests:
+      - elementary.volume_anomalies:
+          anomaly_sensitivity: 2
+          anomaly_direction: both
+          timestamp_column: payment_date  # Assuming there's a 'payment_date' column
+          time_bucket:
+            period: day
+            count: 1
+          detection_period:
+            period: day
+            count: 14
+      - elementary.freshness_anomalies:
+          anomaly_sensitivity: 2
+          timestamp_column: payment_date
+          time_bucket:
+            period: day
+            count: 1
+          detection_period:
+            period: day
+            count: 14


### PR DESCRIPTION
This PR adds recommended tests for the upstream models of cpa_and_roas to improve data quality and consistency:

1. For the `orders` model:
   - Unique test on the `order_id` column
   - Column anomaly test on the `amount` column

2. For the `real_time_orders` model:
   - Custom SQL test to validate the `amount` against `max_price` from `raw_products`

3. For both `stg_orders` and `stg_payments` models:
   - Volume anomaly tests
   - Freshness anomaly tests

These tests will help ensure the reliability of the data feeding into the cpa_and_roas model.<br><br>Created by: `nimrod+demo@elementary-data.com`