### PR TITLE
Mika via Elementary: Fix ROAS anomaly by converting historical order amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +32,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )


### PR DESCRIPTION
## Description

This PR addresses the ROAS (Return on Advertising Spend) anomaly caused by a mismatch in the `amount` calculation between historical and real-time order data. Previously, historical orders had amounts in cents while real-time orders were in dollars, causing a 100x difference in revenue calculations.

## Changes

1. Updated `models/historical_orders.sql`:
   - Converted `op.total_amount` and all payment method amounts from cents to dollars using the `cents_to_dollars` macro.
   - Added a comment to clarify that all monetary amounts in this model are now in dollars.

## Expected Impact

- This change will align the `amount` calculations between historical and real-time orders, resolving the ROAS anomaly.
- The ROAS metric should now be consistent across all time periods.

## Testing

After merging this PR:
1. Rerun the dbt models to apply the changes.
2. Verify that the ROAS anomaly tests pass.
3. Check the `cpa_and_roas` model to ensure the ROAS values are now consistent between historical and recent data.

## Additional Notes

- This change may affect other reports or analyses that rely on the historical orders data. Please review any downstream dependencies to ensure they account for this unit change.
- Consider adding a data quality test to verify that the amounts in both historical and real-time orders are within a similar range to prevent future discrepancies.<br><br>Created by: `mika+demo@elementary-data.com`