### PR TITLE
Michael Myaskovsky via Elementary: Add marketing team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This will ensure that the team is notified when any issues with this model are resolved.

Changes made:
- Updated the `models/marketing/schema.yml` file
- Added `subscribers: "@marketing_team"` to the `meta` section of the cpa_and_roas model

Please review and approve these changes to keep the marketing team informed about the status of this important model.<br><br>Created by: `michael@elementary-data.com`