### PR TITLE
Michael Myaskovsky via Elementary: Change ownership to DE-engineering-team for cpa_and_roas and its dependencies

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Or"
+      owner: "@DE-engineering-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Or"
+      owner: "@DE-engineering-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -118,7 +118,8 @@ models:
   - name: cpa_and_roas
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
-      owner: "Or"
+      owner: "@DE-engineering-team"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -262,7 +263,7 @@ models:
   - name: sessions
     description: "This table contains information on the sessions of all the customers and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Or"
+      owner: "@DE-engineering-team"
     config:
         tags: ["marketing", "pii"]
         elementary:


### PR DESCRIPTION
This PR changes the ownership of the cpa_and_roas model and its immediate upstream dependencies from Or to the DE-engineering-team. This change will ensure that the Data Engineering team has proper ownership and responsibility for these critical models.

Changes made:
- Updated the `models/marketing/schema.yml` file
- Changed the `owner` field from "Or" to "@DE-engineering-team" for the following models:
  1. cpa_and_roas
  2. sessions
  3. attribution_touches
  4. ads_spend

These changes will help streamline the ownership and maintenance of these important data models. The DE-engineering-team will now be responsible for managing and maintaining these models, which should improve overall data quality and consistency.

Please review and approve these changes to update the ownership structure for these critical models.<br><br>Created by: `michael@elementary-data.com`