### PR TITLE
Michael Myaskovsky via Elementary: Add marketing team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This will ensure that the team is notified when issues related to this model are resolved.

Changes:
- Added `subscribers: "@marketing_team"` to the meta section of the cpa_and_roas model in the marketing schema.yml file.

This change will help keep the marketing team informed about the status of the cpa_and_roas model, which is crucial for their analysis and decision-making processes.<br><br>Created by: `michael@elementary-data.com`