### PR TITLE
Michael Myaskovsky via Elementary: Change owner to DE-engineering-team for cpa_and_roas and its dependencies

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Or"
+      owner: "DE-engineering-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Or"
+      owner: "DE-engineering-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -118,7 +118,7 @@ models:
   - name: cpa_and_roas
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
-      owner: "Or"
+      owner: "DE-engineering-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -262,7 +262,7 @@ models:
   - name: sessions
     description: "This table contains information on the sessions of all the customers and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Or"
+      owner: "DE-engineering-team"
     config:
         tags: ["marketing", "pii"]
         elementary:


### PR DESCRIPTION
This PR changes the owner from Or to 'DE-engineering-team' for the cpa_and_roas model and its upstream dependencies. The following changes have been made:

1. Changed the owner of cpa_and_roas to 'DE-engineering-team'
2. Changed the owner of ads_spend to 'DE-engineering-team'
3. Changed the owner of attribution_touches to 'DE-engineering-team'
4. Changed the owner of sessions to 'DE-engineering-team'

These changes will update the ownership of these critical models to reflect the current team structure and responsibilities.<br><br>Created by: `michael@elementary-data.com`