### PR TITLE
Nimrod via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -73,6 +73,8 @@ models:
           config:
             owner: ["@data-ops"]
             tags: ["stability"]
+      - unique:
+          column_name: order_id
     columns:
       - name: order_id
         description: This is a unique identifier for an order
@@ -108,6 +110,13 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
+        tests:
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
+              config:
+                severity: warn
+                owner: ["@data-ops"]
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
@@ -310,6 +319,12 @@ models:
         description: '{{ doc("orders_status") }}'
       - name: amount
         description: "Total order amount (AUD) – already converted to dollars"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "{{ model.amount }} <= (SELECT MAX(price) FROM {{ ref('raw_products') }})"
+              config:
+                severity: warn
+                owner: ["@data-ops"]
       - name: credit_card_amount
         description: "Portion of the order paid with credit card (AUD)"
       - name: coupon_amount

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
This PR adds recommended upstream tests for the cpa_and_roas model, including tests for the orders and real_time_orders models.<br><br>Created by: `nimrod+demo@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anomaly detection on the average value of order amounts in the orders data.
  * Introduced a uniqueness check for order IDs in the orders data.
  * Implemented a validation to ensure order amounts in real-time orders do not exceed product maximum prices.
  * Added volume and freshness anomaly detection for staging orders and payments data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->