### PR TITLE
Michael Myaskovsky via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -73,6 +73,8 @@ models:
           config:
             owner: ["@data-ops"]
             tags: ["stability"]
+      - unique:
+          column_name: order_id  # Assuming order_id is the primary key
     columns:
       - name: order_id
         description: This is a unique identifier for an order
@@ -108,6 +110,12 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
+        tests:
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
+              config:
+                owner: ["@data-ops"]
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
@@ -299,6 +307,9 @@ models:
       tags: ["finance", "sales", "real_time"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "amount <= (select max(price) from {{ source('raw', 'products') }})"
     columns:
       - name: order_id
         description: "Unique identifier for an order"
@@ -318,3 +329,15 @@ models:
         description: "Portion of the order paid with bank transfer (AUD)"
       - name: gift_card_amount
         description: "Portion of the order paid with gift card (AUD)"
+
+  - name: stg_orders
+    description: "Staged orders data"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
+
+  - name: stg_payments
+    description: "Staged payments data"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies


### PR DESCRIPTION
This PR adds new tests for the upstream models of the cpa_and_roas model to improve data quality and reliability. The following changes have been made:

1. Added a unique test on the primary key (order_id) for the orders model.
2. Added a column anomaly test on the amount column for the orders model.
3. Added a custom SQL test for amount validation in the real_time_orders model.
4. Added volume and freshness anomaly tests for the stg_orders and stg_payments models.

These tests will help ensure the accuracy and reliability of the data flowing into the cpa_and_roas model.<br><br>Created by: `michael@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new staging models for orders and payments with basic anomaly detection tests for data volume and freshness.

* **Enhancements**
  * Added a uniqueness validation for order IDs.
  * Implemented anomaly detection for order amounts.
  * Added a rule to ensure real-time order amounts do not exceed the maximum product price.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->