### PR TITLE
Maayan via Elementary: Add marketing team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team (@marketing_team) as a subscriber to the cpa_and_roas model. This will ensure that the marketing team is notified when there are updates or changes to this important model, particularly regarding the resolution of current data quality issues.<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model metadata to include subscriber information for improved team visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->