### PR TITLE
Maayan via Elementary: Fix RETURN_ON_ADVERTISING_SPEND anomaly by converting historical orders to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +31,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
@@ -42,4 +43,4 @@ from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+)


### PR DESCRIPTION
This PR addresses the RETURN_ON_ADVERTISING_SPEND anomaly caused by a mismatch in the `amount` unit between historical and real-time order data.

## Changes

1. Updated `models/historical_orders.sql`:
   - Converted all monetary amounts from cents to dollars using the `cents_to_dollars` macro.
   - Added a comment indicating that all monetary amounts are in dollars.

2. Updated `models/real_time_orders.sql`:
   - Added a comment indicating that all monetary amounts are in dollars (no code changes were necessary).

## Root Cause

The anomaly was caused by historical orders storing amounts in cents, while real-time orders were converting amounts to dollars. This 100x difference in the revenue values was causing the anomaly in the ROAS calculation.

## Expected Outcome

After applying these changes:
1. The RETURN_ON_ADVERTISING_SPEND metric should stabilize and show consistent values across historical and real-time data.
2. The anomaly detection tests for this metric should pass.

## Additional Recommendations

1. Implement a data quality test that compares the scale of amounts between historical and real-time orders to catch any future discrepancies.
2. Review other models and metrics that might be affected by this change, and update them if necessary.

Please review and test these changes thoroughly before merging.<br><br>Created by: `maayan+172@elementary-data.com`