### PR TITLE
Maayan via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -40,6 +40,9 @@ models:
               value_set:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
 
   - name: stg_payments
     meta:
@@ -58,6 +61,9 @@ models:
               config:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
 
   - name: stg_signups
     meta:
@@ -81,3 +87,21 @@ models:
                 severity: warn
               column_anomalies:
                 - missing_count
+
+  - name: orders
+    columns:
+      - name: order_id
+        tests:
+          - unique
+      - name: amount
+        tests:
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
+
+  - name: real_time_orders
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "amount <= (select max(price) from {{ ref('raw_products') }})"
+          config:
+            severity: error


### PR DESCRIPTION
This PR adds the following upstream tests for the cpa_and_roas model:

1. For the orders model:
   - Unique test on order_id
   - Column anomaly test on amount

2. For the real_time_orders model:
   - Custom SQL test to validate that the amount is less than or equal to the max price from raw_products

3. For the stg_orders model:
   - Volume anomaly test
   - Freshness anomaly test

4. For the stg_payments model:
   - Volume anomaly test
   - Freshness anomaly test

These tests will help maintain data quality and integrity across the upstream models that feed into the cpa_and_roas model.<br><br>Created by: `maayan+172@elementary-data.com`