### PR TITLE
Maayan via Elementary: Normalize amount to dollars in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,5 @@
+-- All monetary amounts in this model are in dollars
+
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
This PR addresses the root cause of the anomaly in the `RETURN_ON_ADVERTISING_SPEND` metric by normalizing the `amount` values across both `historical_orders` and `real_time_orders` models.

Changes:
1. Modified the `historical_orders` model to convert the `amount` from cents to dollars using the `cents_to_dollars` macro.
2. Added a comment to the `real_time_orders` model to clarify that all monetary amounts are in dollars.

These changes ensure consistency in the monetary units across both historical and real-time data, which should resolve the anomaly in the `RETURN_ON_ADVERTISING_SPEND` metric.

Next steps after merging:
1. Re-run the dbt models to update the data.
2. Monitor the `RETURN_ON_ADVERTISING_SPEND` metric to ensure the anomaly is resolved.
3. Consider adding a `scale_consistency` test to compare the `amount` columns between `historical_orders` and `real_time_orders` to prevent similar issues in the future.

Closes #[Issue number] (if applicable)<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment amounts in historical orders are now displayed in dollars instead of cents.

* **Documentation**
  * Added a note clarifying that all monetary amounts in real-time orders are expressed in dollars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->