### PR TITLE
Maayan via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -1,83 +1,35 @@
 version: 2
 
 models:
-  - name: stg_customers
-    meta:
-      owner: "Idan"
-    config:
-      tags: ["staging", "pii"]
-    columns:
-      - name: customer_id
-        tests:
-          - unique:
-              config:
-                severity: warn
-          - relationships:
-              to: ref('stg_signups')
-              field: customer_id
+  - name: orders
+    tests:
+      - unique:
+          column_name: order_id
+      - elementary.column_anomalies:
+          column_name: amount
+          anomaly_direction: both
+          detection_period: 7
+          sensitivity: 3
+
+  - name: real_time_orders
+    tests:
+      - elementary.custom_sql:
+          name: amount_less_than_max_price
+          query: |
+            SELECT
+              order_id,
+              amount,
+              max_price
+            FROM {{ model }} AS real_time_orders
+            LEFT JOIN raw_products ON real_time_orders.product_id = raw_products.product_id
+            WHERE amount > max_price
 
   - name: stg_orders
-    meta:
-      owner: "Idan"
-    config:
-      tags: ["staging", "finance", "sales"]
-      elementary:
-        timestamp_column: "order_date"
-    columns:
-      - name: order_id
-        tests:
-          - unique:
-              config:
-                severity: warn
-      - name: status
-        tests:
-          - accepted_values:
-              config:
-                severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
-          - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
-              quote_values: true
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
 
   - name: stg_payments
-    meta:
-      owner: "Idan"
-    config:
-      tags: ["staging", "finance"]
-    columns:
-      - name: payment_id
-        tests:
-          - unique:
-              config:
-                severity: warn
-      - name: payment_method
-        tests:
-          - accepted_values:
-              config:
-                severity: warn
-              values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
-
-  - name: stg_signups
-    meta:
-      owner: "Idan"
-    config:
-      tags: ["staging", "pii"]
-      elementary:
-        timestamp_column: "signup_date"
-    columns:
-      - name: signup_id
-        tests:
-          - unique:
-              config:
-                severity: warn
-      - name: customer_email
-        tests:
-          - unique
-          - elementary.column_anomalies:
-              sensitivity: 2
-              config:
-                severity: warn
-              column_anomalies:
-                - missing_count
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies


### PR DESCRIPTION
This PR adds recommended upstream tests for the cpa_and_roas model. The following tests have been added:

1. For the `orders` model:
   - Unique test on the `order_id` column
   - Column anomaly test on the `amount` column

2. For the `real_time_orders` model:
   - Custom SQL test to validate that the `amount` is less than or equal to the `max_price` from the `raw_products` table

3. For the `stg_orders` model:
   - Volume anomaly test
   - Freshness anomaly test

4. For the `stg_payments` model:
   - Volume anomaly test
   - Freshness anomaly test

These tests will help ensure data quality and integrity in the upstream models that feed into the cpa_and_roas model.<br><br>Created by: `maayan+172@elementary-data.com`