### PR TITLE
Maayan via Elementary: Add marketing team as subscriber for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This will ensure that the marketing team is notified when issues with this model are resolved.

Changes made:
- Updated the `models/marketing/schema.yml` file
- Added `subscribers: "@marketing_team"` to the meta section of the cpa_and_roas model

This change will help keep the marketing team informed about the status of this important model.<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata for the marketing model to include the marketing team as subscribers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->