### PR TITLE
Maayan via Elementary: Fix historical orders amount normalization

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,5 @@
+-- All monetary amounts in this model are in dollars
+
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
This PR addresses the root cause of the anomaly detected in the RETURN_ON_ADVERTISING_SPEND metric. The issue was caused by a mismatch in the unit of the `amount` column between historical and real-time orders.

Changes made:
1. Updated `models/historical_orders.sql` to convert all monetary amounts from cents to dollars using the `cents_to_dollars` macro.
2. Added a comment to `models/real_time_orders.sql` to clarify that all monetary amounts in this model are in dollars.

These changes ensure consistency in the `amount` column across both historical and real-time orders, which should resolve the anomaly in the RETURN_ON_ADVERTISING_SPEND calculation.

After merging this PR, please monitor the RETURN_ON_ADVERTISING_SPEND metric to confirm that the anomaly has been resolved. If any issues persist, further investigation may be needed.

Closes #[Issue number if applicable]<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment amounts in historical orders are now displayed in dollars instead of cents.

* **Documentation**
  * Added a comment clarifying that all monetary amounts in real-time orders are expressed in dollars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->