### PR TITLE
Mika via Elementary: Fix: Normalize historical orders amount to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
This PR addresses an inconsistency in the `amount` field between historical and real-time orders, which was causing anomalies in the `RETURN_ON_ADVERTISING_SPEND` metric calculation.

Changes:
1. In `models/historical_orders.sql`:
   - Updated the `amount` field to use the `cents_to_dollars` macro, converting it from cents to dollars.
   - Applied the same conversion to all payment method amount fields.

2. In `models/real_time_orders.sql`:
   - Added a comment at the top of the file to clarify that all monetary amounts in this model are in dollars.

These changes ensure consistency in the `amount` field across both historical and real-time data, which should resolve the anomalies in the ROAS calculation.

After merging this PR, please monitor the `RETURN_ON_ADVERTISING_SPEND` metric to confirm that the anomalies have been resolved. You may also want to consider adding a data quality test to ensure that the `amount` values in both models are within a similar range to catch any future discrepancies.

Fixes #8d4ce54a-f22a-4bdf-aac9-8c9261a81390<br><br>Created by: `mika+demo@elementary-data.com`