### PR TITLE
Maayan via Elementary: Add new tests for stg_orders model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -29,6 +29,7 @@ models:
           - unique:
               config:
                 severity: warn
+          - not_null
       - name: status
         tests:
           - accepted_values:
@@ -40,6 +41,21 @@ models:
               value_set:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
+      - name: amount
+        tests:
+          - elementary.column_anomalies:
+              column_anomalies:
+                - zero_count
+                - zero_percent
+      - name: customer_id
+        tests:
+          - relationships:
+              to: ref('stg_customers')
+              field: customer_id
+    tests:
+      - elementary.dimension_anomalies:
+          dimensions:
+            - customer_id
 
   - name: stg_payments
     meta:


### PR DESCRIPTION
This PR adds the following new tests to the stg_orders model:

1. not_null test for the order_id column
2. elementary.column_anomalies test for the amount column
3. relationships test for the customer_id column
4. elementary.dimension_anomalies test for the customer_id dimension

These tests will help ensure data integrity and consistency in the stg_orders model.<br><br>Created by: `maayan+172@elementary-data.com`