### PR TITLE
Mika via Elementary: Fix historical orders amount conversion to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )


### PR DESCRIPTION
This PR addresses the root cause of the ROAS anomaly by converting the `amount` column in the `historical_orders` model from cents to dollars, consistent with the `real_time_orders` model.

Changes:
1. Applied `cents_to_dollars` macro to all monetary columns in `historical_orders.sql`.

This change will ensure consistency between historical and real-time order amounts, resolving the 100x discrepancy in the ROAS calculation.

Impact:
- ROAS metric will now be calculated correctly across all time periods.
- Improves accuracy of marketing performance analysis.

Next steps:
1. Review the changes and run tests to ensure they work as expected.
2. After merging, monitor the ROAS metric to confirm the anomaly is resolved.
3. Consider adding a data quality test to compare historical and real-time order amounts to catch any future discrepancies.<br><br>Created by: `mika+demo@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Payment amounts are now displayed in dollars instead of cents across all payment method fields and total amounts in historical order data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->