### PR TITLE
Mika via Elementary: Add tests for cpa_and_roas upstream models

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -40,6 +40,9 @@ models:
               value_set:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
 
   - name: stg_payments
     meta:
@@ -58,6 +61,9 @@ models:
               config:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
 
   - name: stg_signups
     meta:
@@ -81,3 +87,19 @@ models:
                 severity: warn
               column_anomalies:
                 - missing_count
+
+  - name: orders
+    columns:
+      - name: order_id
+        tests:
+          - unique
+      - name: amount
+        tests:
+          - elementary.column_anomalies
+
+  - name: real_time_orders
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "amount <= (select max(price) from {{ source('raw', 'products') }})"
+          config:
+            severity: error


### PR DESCRIPTION
This PR adds the following tests for the upstream models of cpa_and_roas:

1. For the `orders` model:
   - Unique test on the `order_id` column
   - Column anomaly test on the `amount` column

2. For the `real_time_orders` model:
   - Custom SQL test to validate that the `amount` field is less than or equal to the max price from the `raw_products` table

3. For the `stg_orders` model:
   - Volume anomaly test
   - Freshness anomaly test

4. For the `stg_payments` model:
   - Volume anomaly test
   - Freshness anomaly test

These tests will help ensure data quality and integrity for the upstream models that feed into the cpa_and_roas model.<br><br>Created by: `mika+demo@elementary-data.com`