### PR TITLE
Mika via Elementary: Fix ROAS anomaly: Normalize historical and real-time order amounts

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +32,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
This PR addresses the ROAS (Return on Advertising Spend) anomaly caused by a unit mismatch between historical and real-time order amounts.

## Changes

1. Updated `models/historical_orders.sql`:
   - Added a comment clarifying that all monetary amounts are in dollars.
   - Modified the `amount` calculation to use the `cents_to_dollars` macro, ensuring consistency with real-time orders.
   - Applied the `cents_to_dollars` macro to all payment method amounts.

2. Updated `models/real_time_orders.sql`:
   - Added a comment clarifying that all monetary amounts are in dollars.

## Impact

This fix ensures that both historical and real-time order amounts are consistently represented in dollars. This will correct the ROAS calculation in the `cpa_and_roas` model, providing accurate metrics for all time periods.

## Testing

After merging this PR, please:
1. Rebuild the `historical_orders`, `real_time_orders`, and `cpa_and_roas` models.
2. Verify that the ROAS values are consistent across all time periods.
3. Run the full suite of tests to ensure no regressions.

## Additional Recommendations

1. Consider adding a `scale_consistency` test comparing the order amounts between `historical_orders` and `real_time_orders` to catch any future discrepancies.
2. Review other models that might be affected by this change and update them if necessary.
3. Update any dashboards or reports that rely on the `cpa_and_roas` model to reflect the corrected ROAS values.<br><br>Created by: `mika+demo@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment amounts are now consistently displayed in dollars instead of cents in order reports.

* **Documentation**
  * Added comments clarifying that all monetary amounts are expressed in dollars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->