### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix historical orders amount conversion

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )


### PR DESCRIPTION
This PR fixes the root cause of the RETURN_ON_ADVERTISING_SPEND anomaly by converting the amount column in historical_orders from cents to dollars. This ensures consistency with the real_time_orders model and resolves the 100x difference in revenue calculations.

Changes made:
- Updated the `amount` column calculation in `historical_orders.sql` to use the `cents_to_dollars` macro.
- Applied the `cents_to_dollars` conversion to all payment method amounts for consistency.

After merging this PR, please run a full refresh of the affected models to ensure the data is correctly updated.<br><br>Created by: `joost@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the display of payment amounts from cents to dollars for all payment methods and total amounts in historical orders. Users will now see payment values in dollars instead of cents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->