### PR TITLE
Joost Boonzajer Flaes via Elementary: Add comment to real_time_orders model about monetary units

### DIFF
--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
This PR adds a comment to the `real_time_orders.sql` file to clearly indicate that all monetary amounts in this model are in dollars. This helps prevent future confusion about the units used in this model.

Changes made:
- Added a comment at the top of the `real_time_orders.sql` file stating that all monetary amounts are in dollars.

This change, combined with the previous PR to fix the `historical_orders` model, should help maintain consistency in monetary units across the project and prevent similar issues in the future.<br><br>Created by: `joost@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note clarifying that all monetary amounts are expressed in dollars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->