### PR TITLE
Maayan via Elementary: Update owners for marketing models

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -33,7 +33,7 @@ models:
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session, with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -118,7 +118,7 @@ models:
   - name: cpa_and_roas
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -262,7 +262,7 @@ models:
   - name: sessions
     description: "This table contains information on the sessions of all the customers and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
         tags: ["marketing", "pii"]
         elementary:


### PR DESCRIPTION
This PR updates the owners for the following models from "Or" to "de-engineering-team":

- cpa_and_roas
- sessions
- attribution_touches
- ads_spend

These changes were requested to reflect the new ownership structure for these marketing-related models.<br><br>Created by: `maayan+172@elementary-data.com`