### PR TITLE
Maayan via Elementary: Fix inconsistent amount units in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +32,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
This PR addresses the root cause of the anomaly detected in the `RETURN_ON_ADVERTISING_SPEND` metric. The issue was caused by inconsistent units for the `amount` field between the `historical_orders` and `real_time_orders` models.

Changes made:
1. Updated the `historical_orders` model to convert the amount from cents to dollars, consistent with the `real_time_orders` model.
2. Added comments in both `historical_orders.sql` and `real_time_orders.sql` to clearly indicate that all monetary amounts are in dollars.

These changes will ensure consistent data is fed into the `customer_conversions`, `attribution_touches`, and ultimately the `cpa_and_roas` models, resolving the anomaly in the `RETURN_ON_ADVERTISING_SPEND` calculation.

After merging this PR, we expect the `column_anomalies` test on the `RETURN_ON_ADVERTISING_SPEND` metric to pass, and the incident should be resolved.<br><br>Created by: `maayan+172@elementary-data.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added comments to clarify that all monetary amounts are now represented in dollars.

* **Refactor**
  * Updated monetary amount fields to be displayed in dollars instead of cents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->