### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix discrepancy in amount unit between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +32,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
This PR addresses the root cause of the anomaly detected in the `RETURN_ON_ADVERTISING_SPEND` calculation. The issue was caused by a mismatch in the unit of the `amount` column between historical and real-time order data.

Changes made:
1. Updated the `historical_orders` model to convert the amount from cents to dollars, consistent with the `real_time_orders` model.
2. Added comments in both `historical_orders` and `real_time_orders` models to clearly indicate that all monetary amounts are in dollars.

These changes ensure consistent units across both historical and real-time data, which should resolve the 100x difference in the calculated ROAS for recent data compared to historical data.

After merging this PR, the anomaly in the `RETURN_ON_ADVERTISING_SPEND` calculation should be resolved. However, it's recommended to monitor the metrics closely after the changes are applied to ensure the expected behavior.<br><br>Created by: `joost@elementary-data.com`