### PR TITLE
Maayan via Elementary: Add marketing team as subscriber for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas table. This will ensure they're notified when any issues related to this table are resolved.

Changes made:
- Updated the `models/marketing/schema.yml` file
- Added `subscribers: "@marketing_team"` to the meta section of the cpa_and_roas model

This change will help keep the marketing team informed about the status of this critical data asset.<br><br>Created by: `maayan+172@elementary-data.com`