### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix historical orders amount conversion from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Description

This PR fixes a critical issue where the `historical_orders` model was not properly converting monetary amounts from cents to dollars, while the `real_time_orders` model was correctly doing this conversion.

This mismatch caused the `cpa_and_roas` model to calculate incorrect RETURN_ON_ADVERTISING_SPEND values when historical data was included, leading to anomaly detection test failures.

## Changes

1. Updated `historical_orders.sql` to use the `cents_to_dollars` macro for all monetary fields
2. Added a comment to `real_time_orders.sql` to clearly document that all monetary amounts in this model are in dollars

## Testing

After applying this fix, the anomaly detection test for RETURN_ON_ADVERTISING_SPEND should pass, as the revenue values will be consistent across both historical and real-time data.<br><br>Created by: `joost@elementary-data.com`