### PR TITLE
Maayan via Elementary: Add marketing_team as a subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Or"
+      subscribers: ["@marketing_team"]
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This will ensure that the marketing team receives notifications when data incidents related to this model are resolved.

The change adds `subscribers: ["@marketing_team"]` to the model's metadata in the marketing schema.yml file.<br><br>Created by: `maayan+172@elementary-data.com`