### PR TITLE
Maayan via Elementary: Fix unit mismatch in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The anomaly detection test for RETURN_ON_ADVERTISING_SPEND in the cpa_and_roas model is failing due to a unit mismatch between historical_orders and real_time_orders.

## Root Cause
In historical_orders.sql, the amount is kept in cents, while in real_time_orders.sql, the amount is converted to dollars using the cents_to_dollars macro. This creates a 100x inconsistency when these values flow up to the ROAS calculation.

## Changes
- Applied the cents_to_dollars macro to all monetary fields in historical_orders.sql
- Added a comment to real_time_orders.sql to document that all monetary amounts are in dollars

## Testing
The change should resolve the RETURN_ON_ADVERTISING_SPEND column anomaly by ensuring consistent monetary units throughout the pipeline.<br><br>Created by: `maayan+172@elementary-data.com`