### PR TITLE
Mika via Elementary: Add marketing team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -119,6 +119,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This ensures that the marketing team will be notified when the current data quality issues affecting the ROAS calculations are resolved.

Changes:
- Added `@marketing_team` as a subscriber in the cpa_and_roas model metadata<br><br>Created by: `mika+demo@elementary-data.com`