### PR TITLE
Mika via Elementary: Fix unit inconsistency between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Problem

The `historical_orders` model incorrectly uses `amount` values in cents, while `real_time_orders` correctly converts cents to dollars. When these models are combined in the `orders` model, this inconsistency propagates up through the data pipeline and causes anomalies in metrics like Return on Ad Spend (ROAS).

## Solution

1. Applied the `cents_to_dollars` macro to all monetary columns in `historical_orders` model
2. Added a clarifying comment to the `real_time_orders` model to document that amounts are in dollars

## Testing

- After this change, the monetary values will be consistently in dollars throughout the pipeline
- The ROAS calculation in `cpa_and_roas` should return to expected values
- The failing anomaly tests should resolve

Fixes incident: c4aef70f-03aa-4511-acee-04d8a5fad0e5<br><br>Created by: `mika+demo@elementary-data.com`