### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix historical orders cents to dollars conversion

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Issue
The historical_orders model was treating monetary values as dollars when they were actually in cents, while the real_time_orders model was correctly converting cents to dollars. This caused a significant anomaly in ROAS metrics when data from both sources was combined.

## Changes
- Modified historical_orders.sql to rename total_amount to amount_cents for clarity
- Added conversion of all monetary values from cents to dollars using the cents_to_dollars macro
- Added a clarifying comment to real_time_orders.sql indicating that monetary values are in dollars
- Standardized the format of both models to make them more consistent

## Impact
This fix will normalize all monetary values across the pipeline, ensuring that the return_on_advertising_spend metric is calculated consistently. Once deployed, we should see the anomaly alerts resolve themselves as the metric returns to expected values.<br><br>Created by: `joost@elementary-data.com`