### PR TITLE
Joost Boonzajer Flaes via Elementary: Add marketing team as subscriber for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds @marketing_team as a subscriber for the cpa_and_roas model. 

The marketing team will now receive notifications when the current data quality issues with this model are resolved, including:
- The HIGH severity column_anomalies issue affecting RETURN_ON_ADVERTISING_SPEND_PERCENTAGE
- Freshness anomalies
- Volume anomalies

This will keep the marketing team informed about the health of this critical ROAS data.<br><br>Created by: `joost@elementary-data.com`