### PR TITLE
Joost Boonzajer Flaes via Elementary: Add marketing_team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: ["@marketing_team"]
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This will ensure the marketing team gets notified when data issues affecting this model are resolved.

The change adds `subscribers: ["@marketing_team"]` to the cpa_and_roas model metadata in the schema.yml file.<br><br>Created by: `joost@elementary-data.com`