### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix monetary unit inconsistency between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Issue
The column anomaly test on `RETURN_ON_ADVERTISING_SPEND_PERCENTAGE` in the `cpa_and_roas` table is failing because the underlying monetary data is inconsistent between historical and real-time orders.

## Root Cause
- `real_time_orders.sql` correctly converts `amount_cents` to dollars using the `cents_to_dollars` macro
- `historical_orders.sql` was not applying the same conversion, leaving monetary values as cents (100× larger)
- This resulted in ROAS values being ~100× smaller when real-time data was involved, triggering the anomaly detection

## Changes
1. Added the `cents_to_dollars` conversion to all monetary fields in `historical_orders.sql`
2. Added a documentation comment to `real_time_orders.sql` to clarify that all monetary values are in dollars
3. No changes to logic in real-time orders, just added documentation

## Testing
This change will ensure consistent unit representation across both historical and real-time data, resolving the ROAS anomaly detection issue.<br><br>Created by: `joost@elementary-data.com`