### PR TITLE
Joost Boonzajer Flaes via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -76,6 +76,8 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tests:
+          - unique
 
       - name: customer_id
         description: Foreign key to the customers table
@@ -108,6 +110,12 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
+        tests:
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
+              config:
+                severity: warn
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
@@ -318,3 +326,8 @@ models:
         description: "Portion of the order paid with bank transfer (AUD)"
       - name: gift_card_amount
         description: "Portion of the order paid with gift card (AUD)"
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "amount <= (select max(price) from {{ source('raw_data', 'raw_products') }})"
+          config:
+            severity: warn

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -40,6 +40,9 @@ models:
               value_set:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
 
   - name: stg_payments
     meta:
@@ -58,6 +61,9 @@ models:
               config:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
 
   - name: stg_signups
     meta:


### PR DESCRIPTION
This PR adds critical data quality tests for upstream dependencies of the cpa_and_roas model:

1. Added a unique test for the order_id column in the orders model to ensure data integrity
2. Added column anomaly detection for the amount column in orders model since it feeds into return_on_advertising_spend calculations
3. Added a custom SQL test for real_time_orders to validate that the amount field is within expected range based on raw_products data
4. Added volume and freshness anomaly tests for both stg_orders and stg_payments models

These tests will help ensure that the data flowing into cpa_and_roas maintains high quality and reliability.<br><br>Created by: `joost@elementary-data.com`