### PR TITLE
Maayan via Elementary: Add tests for cpa_and_roas upstream models

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:
@@ -81,3 +87,30 @@ models:
                 severity: warn
               column_anomalies:
                 - missing_count
+
+  - name: orders
+    columns:
+      - name: order_id
+        tests:
+          - unique
+      - name: amount
+        tests:
+          - elementary.column_anomalies:
+              anomaly_sensitivity: 2
+              column_anomalies:
+                - average
+                - sum
+                - min
+                - max
+              time_bucket:
+                period: day
+                count: 1
+              training_period:
+                period: day
+                count: 14
+
+  - name: real_time_orders
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "amount <= (select max(price) from {{ source('products', 'raw_products') }})"
+          severity: error


### PR DESCRIPTION
This PR adds critical tests to upstream models that feed into the cpa_and_roas calculations:

1. For the `orders` model:
   - Added unique test on order_id
   - Added column_anomalies test on amount column that directly affects ROAS calculations

2. For the `real_time_orders` model:
   - Added SQL expression test to validate amount field against max price in raw_products

3. For staging models:
   - Added volume_anomalies and freshness_anomalies tests to stg_orders and stg_payments

These tests will help ensure data quality and integrity throughout the pipeline that feeds into marketing performance calculations.<br><br>Created by: `maayan+172@elementary-data.com`