### PR TITLE
Michael Myaskovsky via Elementary: Add marketing team as subscriber for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds @marketing_team as a subscriber to the cpa_and_roas model. 

This will ensure the marketing team receives notifications when the current data issues are resolved, including:
- Freshness anomalies
- Volume anomalies 
- Column anomalies affecting the RETURN_ON_ADVERTISING_SPEND_PERCENTAGE

No other changes were made to the existing configuration.<br><br>Created by: `michael@elementary-data.com`