### PR TITLE
Michael Myaskovsky via Elementary: Fix unit normalization issue in historical_orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `historical_orders` model doesn't convert monetary values from cents to dollars, while `real_time_orders` does. This inconsistency causes anomalies in the ROAS (Return on Advertising Spend) metric that's being calculated in downstream models.

## Solution
Added the `cents_to_dollars` macro to the `historical_orders` model to normalize all monetary amounts, ensuring consistency with the `real_time_orders` model which was already doing the conversion.

Additionally, added a comment at the top of `real_time_orders.sql` to clearly document that values are stored in dollars, which will help prevent future issues.

## Impact
This will fix the anomalies being detected in the `cpa_and_roas` model's RETURN_ON_ADVERTISING_SPEND_PERCENTAGE column, which was triggering the HIGH severity incident.<br><br>Created by: `michael@elementary-data.com`