### PR TITLE
Michael Myaskovsky via Elementary: Update owner from Or to de-engineering-team for marketing models

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -36,7 +36,7 @@ models:
     description: "This is a table that contains all the touch points, by session,
       with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -124,7 +124,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend,
       by source, and per day"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
       tags:
         - "finance"
@@ -278,7 +278,7 @@ models:
     description: "This table contains information on the sessions of all the customers
       and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Or"
+      owner: "de-engineering-team"
     config:
       tags: ["marketing", "pii"]
       elementary:


### PR DESCRIPTION
This PR changes the owner from "Or" to "de-engineering-team" for the following models:

- cpa_and_roas
- attribution_touches
- sessions
- ads_spend

These changes ensure consistent ownership across the marketing models used in the cost per acquisition and return on ad spend calculations.<br><br>Created by: `michael@elementary-data.com`