### PR TITLE
Michael Myaskovsky via Elementary: Fix monetary unit inconsistency causing ROAS anomaly

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,5 @@
+-- All monetary amounts in this model are in dollars
+
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The anomaly detection test on RETURN_ON_ADVERTISING_SPEND is failing because of a unit inconsistency between the `historical_orders` and `real_time_orders` models.

- The `real_time_orders` model properly converts monetary values from cents to dollars using the `cents_to_dollars` macro
- The `historical_orders` model doesn't perform any conversion, keeping values in cents

When these models are unioned in the `orders` model, this creates inconsistent units that flow through the pipeline, causing ROAS calculations to be significantly off.

## Solution
This PR:
1. Modifies `historical_orders.sql` to convert monetary values from cents to dollars using the `cents_to_dollars` macro, just like `real_time_orders` does
2. Adds a comment to `real_time_orders.sql` to make it explicit that monetary amounts are in dollars

## Testing
After this change, the unit consistency should be fixed and the anomaly detection test should pass once the models are rerun.<br><br>Created by: `michael@elementary-data.com`