### PR TITLE
Mika via Elementary: Add marketing_team as subscriber for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model. This will ensure the team is notified of any changes in model health or when the current issues are resolved.

Changes made:
- Added `@marketing_team` as a subscriber in the meta section of the cpa_and_roas model definition<br><br>Created by: `mika+demo@elementary-data.com`