### PR TITLE
Mika via Elementary: Fix monetary unit mismatch in historical orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `historical_orders` model was storing monetary amounts in cents while the `real_time_orders` model was converting them to dollars. This inconsistency caused:

1. A union of mixed units in the `orders` model
2. Propagation of inconsistent values through the analytics pipeline
3. Anomalies in the ROAS (Return on Ad Spend) calculations
4. High-severity alerts in Elementary

## Changes
- Updated `historical_orders.sql` to use the `cents_to_dollars` macro for all monetary fields
- Added a clear comment at the top of `real_time_orders.sql` to document that values are in dollars

## Testing
Once merged, please verify that:
1. The ROAS values stabilize
2. The anomaly tests pass consistently
3. Finance reports show consistent values<br><br>Created by: `mika+demo@elementary-data.com`