### PR TITLE
Mika via Elementary: Fix historical_orders model to convert monetary values from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -30,9 +28,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,6 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
+
+-- All monetary amounts in this model are in dollars
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Description
This PR fixes an inconsistency in how monetary values are handled between `historical_orders` and `real_time_orders` models.

### Issue
- The `real_time_orders` model correctly converts monetary values from cents to dollars using the `cents_to_dollars` macro
- The `historical_orders` model was not applying this conversion, leaving values in cents
- This inconsistency caused anomalous values in downstream metrics, particularly affecting the `return_on_advertising_spend` calculations

### Changes
- Added `cents_to_dollars` conversion to all monetary fields in `historical_orders` model
- Added a clarifying comment to the `real_time_orders` model to document that values are in dollars

This should resolve the anomalies detected in the `cpa_and_roas` model's ROAS metrics.<br><br>Created by: `mika+demo@elementary-data.com`