### PR TITLE
Joost Boonzajer Flaes via Elementary: Add marketing_team as subscriber for cpa_and_roas table

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas table. This will ensure the marketing team is notified when the current data quality issues are resolved.

Changes made:
- Added `@marketing_team` as a subscriber in the `meta` section of the cpa_and_roas model definition in schema.yml<br><br>Created by: `joost@elementary-data.com`