### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch between historical_orders and real_time_orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Description
This PR fixes a critical unit mismatch between the historical_orders and real_time_orders models that was causing anomalies in the RETURN_ON_ADVERTISING_SPEND metric.

## Problem
- real_time_orders: Uses the `cents_to_dollars` macro to convert amounts to dollars
- historical_orders: Passes through amounts in cents without conversion

This resulted in a ~100× scale difference in the data feeding into downstream models, causing the ROAS calculation to be inconsistent.

## Changes
1. Modified historical_orders.sql to:
   - Rename the amount column to amount_cents for clarity
   - Apply the cents_to_dollars macro to all monetary values
   - Use consistent formatting with real_time_orders

2. Added documentation comment to real_time_orders.sql to clarify that all monetary values are in dollars

## Impact
This fix will normalize all monetary values across the pipeline, ensuring that calculations like ROAS are consistent regardless of whether the data comes from historical or real-time sources.<br><br>Created by: `joost@elementary-data.com`