### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -30,9 +28,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,7 +1,6 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## What's the issue?\n\nThe column anomaly test for `RETURN_ON_ADVERTISING_SPEND` is failing because of a unit mismatch between `historical_orders` and `real_time_orders` models.\n\n- In `real_time_orders`, the `amount` field is properly converted from cents to dollars using the `cents_to_dollars` macro\n- In `historical_orders`, the `amount` field is used directly without conversion, remaining in cents\n\nThis causes a 100x difference in values between recent and historical data, triggering the anomaly detection test.\n\n## What does this PR do?\n\n1. Updates `historical_orders.sql` to apply the `cents_to_dollars` macro to all monetary fields\n2. Adds a clarifying comment to `real_time_orders.sql` to indicate all monetary amounts are in dollars\n\nAfter this change, all monetary values will be consistently in dollars throughout the pipeline, and the anomaly detection test should return to normal.<br><br>Created by: `joost@elementary-data.com`