### PR TITLE
Mika via Elementary: Fix historical_orders model to convert cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Description

This PR fixes an issue where the `historical_orders` model was using monetary values in cents while `real_time_orders` was converting them to dollars. This inconsistency was causing a significant anomaly in the `RETURN_ON_ADVERTISING_SPEND` metric in the downstream `cpa_and_roas` model.

## Changes

1. Updated `historical_orders.sql` to use the `cents_to_dollars` macro for all monetary columns
2. Added a clarifying comment in `real_time_orders.sql` to document that values are in dollars

## Impact

This fix will ensure consistent monetary units across the `orders` model, which will fix the anomaly in `RETURN_ON_ADVERTISING_SPEND` calculations.

## Related Issues

- Resolves incident with ID: 1f6f38ea-e8ef-475b-b957-a8effe32b5b4<br><br>Created by: `mika+demo@elementary-data.com`