### PR TITLE
Mika via Elementary: Add marketing-team as a subscriber to cpa_and_roas table

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas table. This will ensure that the marketing team receives notifications when data quality issues related to this table are resolved.

The change adds `@marketing_team` as a subscriber in the model's metadata in the marketing schema.yml file.<br><br>Created by: `mika+demo@elementary-data.com`