### PR TITLE
Mika via Elementary: Fix unit mismatch between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Problem

An anomaly was detected in the `RETURN_ON_ADVERTISING_SPEND` metric due to a unit inconsistency between historical and real-time orders.

## Root Cause

- `real_time_orders.sql` correctly converts monetary amounts from cents to dollars using the `cents_to_dollars()` macro
- `historical_orders.sql` doesn't perform this conversion, causing a 100x difference in magnitude

## Changes

1. Added proper unit conversion in `historical_orders.sql` using the `cents_to_dollars()` macro for all monetary fields
2. Added a comment in `real_time_orders.sql` to explicitly document that monetary values are in dollars

This fix will ensure consistent units across all orders, which will correct the RETURN_ON_ADVERTISING_SPEND calculation in the cpa_and_roas model.<br><br>Created by: `mika+demo@elementary-data.com`