### PR TITLE
Maayan via Elementary: Fix monetary unit inconsistency between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The column anomaly test for `RETURN_ON_ADVERTISING_SPEND` in the `cpa_and_roas` model is failing due to an inconsistency in monetary units between `historical_orders` and `real_time_orders`.

- `real_time_orders` converts cents to dollars using the `cents_to_dollars` macro
- `historical_orders` was using the raw values in cents without conversion

This causes a 100x difference in values when the models are combined, which propagates to the ROAS calculation.

## Changes
1. Modified `historical_orders.sql` to:
   - Rename `total_amount` to `amount_cents` 
   - Use the `cents_to_dollars` macro to convert all monetary values
   - Update the SELECT statement to use the converted values

2. Added a clarifying comment to `real_time_orders.sql` about monetary units

## Testing
After this change, the values in the combined `orders` model should be consistently in dollars, resolving the anomaly in `RETURN_ON_ADVERTISING_SPEND`.<br><br>Created by: `maayan+172@elementary-data.com`