### PR TITLE
Maayan via Elementary: Fix ROAS anomaly: Convert historical_orders amount to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are converted to dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +31,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Description
This PR fixes the root cause of the RETURN_ON_ADVERTISING_SPEND anomaly detected in the cpa_and_roas model.

### Problem
- The `historical_orders` model was storing monetary values in cents, while `real_time_orders` was converting to dollars
- When combined in the `orders` model, this created inconsistent units flowing through to `customer_conversions` → `attribution_touches` → `cpa_and_roas`
- This caused the anomalous ROAS values, as historical revenue was ~100x higher than it should be relative to ad spend

### Fix
- Apply the `cents_to_dollars` macro to all monetary fields in `historical_orders` just like in `real_time_orders`
- Add clear documentation comments in both files to document the unit expectations
- This ensures consistent monetary units throughout the data pipeline

### Impact
This will resolve the anomaly in the RETURN_ON_ADVERTISING_SPEND column and provide more accurate marketing attribution metrics.<br><br>Created by: `maayan+172@elementary-data.com`