### PR TITLE
Maayan via Elementary: Add upstream tests for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
This PR adds recommended upstream tests for the `cpa_and_roas` model:

1. For `stg_orders`:
   - Added volume anomaly test to detect unexpected changes in order volume
   - Added freshness anomaly test to ensure data is regularly updated

2. For `stg_payments`:
   - Added volume anomaly test to monitor payment transaction volume
   - Added freshness anomaly test to ensure financial data freshness

These tests will help ensure the reliability of the data that feeds into the cpa_and_roas model and improve overall data quality monitoring.

Note: Additional tests for the `orders` and `real_time_orders` models will need to be added in separate PRs as they are in different directories.<br><br>Created by: `maayan+172@elementary-data.com`