### PR TITLE
Mika Kerman via Elementary: Add marketing-team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: ["marketing-team"]
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds marketing-team as a subscriber to the cpa_and_roas model.

The marketing team will now receive notifications when issues are resolved with the model, particularly the current high severity incident affecting the RETURN_ON_ADVERTISING_SPEND column.

Related incident: #412df8fc-c6ce-4070-9f10-27bfb0209650<br><br>Created by: `mika@elementary-data.com`