### PR TITLE
Mika via Elementary: Fix monetary unit inconsistency between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,8 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
+
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Description

This PR fixes a critical issue causing anomalies in the `RETURN_ON_ADVERTISING_SPEND` metric in the `cpa_and_roas` model.

### Root Cause
- The `historical_orders` model was using monetary amounts in **cents** without conversion
- The `real_time_orders` model was correctly converting monetary amounts to **dollars** using the `cents_to_dollars` macro
- This 100x difference in units caused significant anomalies when calculating ROAS metrics

### Changes Made
1. Updated `historical_orders.sql` to:
   - Rename `amount` to `amount_cents` in the final CTE (for clarity)
   - Apply the `cents_to_dollars` macro to all monetary fields in the output query
   - Match the pattern used in the real_time_orders model

2. Added a clarifying comment to `real_time_orders.sql` to make the units explicit

### Expected Outcomes
- Consistent monetary units (dollars) throughout the pipeline
- Resolution of the anomaly detection alerts on the ROAS metric
- More accurate financial reporting

### Testing
The next run should show ROAS values within expected ranges, and the anomaly tests should pass.<br><br>Created by: `mika+demo@elementary-data.com`