### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix monetary unit inconsistency between real_time_orders and historical_orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -30,9 +28,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,6 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
+
+-- All monetary amounts in this model are in dollars
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Problem

The anomaly detection test for RETURN_ON_ADVERTISING_SPEND has been failing due to a unit inconsistency between `real_time_orders` and `historical_orders`.

- `real_time_orders` correctly converts monetary values from cents to dollars using the `cents_to_dollars` macro
- `historical_orders` was using the raw amount values directly (in cents)

This 100x difference in scale was causing the anomaly test to fail.

## Solution

1. Added the `cents_to_dollars` macro calls to convert all monetary fields in `historical_orders` model
2. Added a comment at the top of `real_time_orders` to document that amounts are in dollars

## Testing
After this change, the ROAS values from both sources should be at the same scale, and the anomaly detection test should pass.<br><br>Created by: `joost@elementary-data.com`