### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix historical orders amount conversion

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Problem
The historical_orders model was not converting monetary amounts from cents to dollars, while real_time_orders was. This inconsistency caused a 100x scale difference in the return_on_advertising_spend metric, triggering anomaly detection tests.

## Changes
- Modified historical_orders.sql to convert all monetary amounts from cents to dollars
- Renamed the column to amount_cents before conversion for clarity
- Added a comment to real_time_orders.sql to document that monetary values are in dollars
- Used the same cents_to_dollars macro for consistency across both models

## Testing
This change will normalize all historical order amounts to match real_time orders, which should resolve the column anomaly test failures on the cpa_and_roas model.<br><br>Created by: `joost@elementary-data.com`