### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Issue

The RETURN_ON_ADVERTISING_SPEND column in the cpa_and_roas model is failing anomaly detection tests because of inconsistent unit normalization in the data pipeline.

## Root Cause

The real_time_orders model correctly converts monetary values from cents to dollars using the cents_to_dollars macro, but the historical_orders model uses the raw values (in cents) without conversion.

This creates a 100x difference in the amount values between historical and recent orders, which propagates through the pipeline to the ROAS calculations.

## Changes

- Applied cents_to_dollars macro to all monetary amounts in historical_orders model
- Added explicit comment to real_time_orders model indicating units
- Fixed inconsistent parameter naming in historical_orders model

## Testing

These changes should resolve the column anomaly on the RETURN_ON_ADVERTISING_SPEND metric. Once deployed, the anomaly detection test should pass.<br><br>Created by: `joost@elementary-data.com`