### PR TITLE
Mika via Elementary: Fix monetary unit mismatch between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Problem

The anomaly detection test on the `RETURN_ON_ADVERTISING_SPEND` column in the `cpa_and_roas` table is failing because of a unit mismatch between historical and real-time orders data:

- `real_time_orders` correctly converts monetary values from cents to dollars using the `cents_to_dollars` macro
- `historical_orders` does not perform this conversion, leaving amounts in cents
- When combined in the `orders` UNION, this creates a 100× difference in amounts

## Solution

This PR modifies the `historical_orders.sql` model to:
1. Convert all monetary amounts from cents to dollars using the same `cents_to_dollars` macro
2. Keep the structure consistent with `real_time_orders`

It also adds a clarifying comment to `real_time_orders.sql` to document that monetary values in that model are in dollars.

## Impact
- Fixes the ROAS anomaly by ensuring consistent units
- Ensures accurate financial reporting
- Makes the model more maintainable by normalizing units across the pipeline<br><br>Created by: `mika+demo@elementary-data.com`