### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit inconsistency in historical orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Issue

This PR fixes a critical issue that was causing the anomaly detection test on `RETURN_ON_ADVERTISING_SPEND` to fail.

The root cause was an inconsistency between:
- `historical_orders`: monetary values were in **cents**
- `real_time_orders`: monetary values were in **dollars** (properly converted)

This resulted in a ~100x difference in the calculated ROAS values between historical and recent data.

## Changes

1. Modified `historical_orders.sql` to use the `cents_to_dollars` macro for all monetary amounts, ensuring consistent units across all order data
2. Added a comment at the top of `real_time_orders.sql` to explicitly document that amounts are in dollars

## Tested
- The fix addresses the root cause of the anomaly detection test failure by ensuring all monetary values use the same unit (dollars)
- The changes are minimal and focused on the specific issue<br><br>Created by: `joost@elementary-data.com`