### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix monetary unit normalization in historical_orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    amount_cents
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -2,6 +2,7 @@
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Problem
The `historical_orders` model was using monetary amounts in cents, but labeling them as dollars, while the `real_time_orders` model was properly converting cents to dollars. This inconsistency has caused anomalies in the `RETURN_ON_ADVERTISING_SPEND` metrics in the `cpa_and_roas` model.

## Solution
- Update `historical_orders.sql` to rename the total_amount field to amount_cents
- Use the cents_to_dollars macro to properly convert all monetary values to dollars
- Add a clarifying comment in `real_time_orders.sql` to indicate that all monetary amounts are in dollars

## Testing
After this change, the ROAS values should normalize and the column_anomalies tests should pass.<br><br>Created by: `joost@elementary-data.com`