### PR TITLE
Mika via Elementary: Add marketing team subscription to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team (@marketing_team) as a subscriber to the cpa_and_roas model to ensure they receive notifications when data quality issues are resolved.

Changes:
- Added `subscribers: "@marketing_team"` to the cpa_and_roas model metadata in models/marketing/schema.yml

This will ensure the marketing team is notified about:
- Incident resolutions
- Data quality status changes
- Model execution updates

The change is made to help track the resolution of the current critical anomaly in the RETURN_ON_ADVERTISING_SPEND column.<br><br>Created by: `mika+demo@elementary-data.com`