### PR TITLE
Maayan via Elementary: Add marketing team subscriber to cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model to ensure they receive notifications when data quality issues are resolved.

Changes:
- Added subscribers field with @marketing_team to the cpa_and_roas model in models/marketing/schema.yml<br><br>Created by: `maayan+172@elementary-data.com`