### PR TITLE
Michael Myaskovsky via Elementary: Add subscriber to cpa_and_roas model for incident notifications

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "Or"
+      subscribers: "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the cpa_and_roas model to ensure they receive notifications when data quality issues are resolved.

Changes:
- Added `subscribers: "@marketing_team"` to the cpa_and_roas model meta section in models/marketing/schema.yml

This will enable automatic notifications when the current data quality incidents (freshness anomalies and column anomalies on RETURN_ON_ADVERTISING_SPEND) are resolved.<br><br>Created by: `michael@elementary-data.com`