### PR TITLE
Joost Boonzajer Flaes via Elementary: Add data quality tests for marketing_ads model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -187,14 +187,21 @@ models:
       tags: ["marketing", "finance"]
       elementary:
         timestamp_column: "date"
+    data_tests:
+      - unique:
+          column_name: ad_id
     columns:
       - name: ad_id
         data_type: varchar
         description: "Unique identifier for an ad"
+        data_tests:
+          - not_null
 
       - name: date
         data_type: date
         description: "date (UTC) when the ad was displayed"
+        data_tests:
+          - not_null
 
       - name: utm_medium
         data_type: varchar
@@ -208,6 +215,10 @@ models:
       - name: cost
         data_type: number
         description: "Cost (USD) accumulated of the ad presentations so far"
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
 
       - name: utm_source
         data_type: varchar


### PR DESCRIPTION
This PR adds essential data quality tests for the `marketing_ads` model to ensure data integrity for the downstream `ads_spend` aggregation:

## Tests Added:
- **Unique constraint on ad_id**: Prevents duplicate ad records that could lead to inflated spend calculations
- **Not null checks on cost and date**: Ensures critical fields required for spend aggregation are always present
- **Range validation on cost**: Ensures cost values are non-negative, preventing unrealistic negative advertising costs

These tests complement the existing volume and freshness anomaly detection and focus on business logic validation for accurate spend reporting.<br><br>Created by: `joost@elementary-data.com`