### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🚧 **Root Cause Fixed**
This PR resolves the **column anomaly** on `RETURN_ON_ADVERTISING_SPEND` by fixing the unit mismatch between `historical_orders` and `real_time_orders` models.

## 🔍 **Issue Summary**
The ROAS anomaly was caused by inconsistent monetary units:
- **real_time_orders.amount**: Already normalized to **dollars** 
- **historical_orders.amount**: Still in **cents** (100× difference)

When these datasets are UNIONed in the `orders` model, it creates a 100× mismatch that propagates through the entire calculation chain:
`historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas` → **ROAS anomaly test failure**

## 🛠️ **Changes Made**
1. **historical_orders.sql**: Convert all monetary amounts from cents to dollars using the `cents_to_dollars()` macro
2. **real_time_orders.sql**: Add clarifying comment at the top about unit expectations

## ✅ **Expected Outcome**
- Column anomaly test on `RETURN_ON_ADVERTISING_SPEND` should pass
- Consistent monetary units across the entire orders pipeline
- No more 100× inflation in revenue calculations from historical data<br><br>Created by: `joost@elementary-data.com`