### PR TITLE
Joost Boonzajer Flaes via Elementary: Add upstream tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,20 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+          time_bucket:
+            period: day
+            count: 1
+          detection_period:
+            period: day
+            count: 7
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
+          timestamp_column: "order_date"
     columns:
       - name: order_id
         tests:
@@ -46,6 +60,19 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+          time_bucket:
+            period: day
+            count: 1
+          detection_period:
+            period: day
+            count: 7
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
This PR adds critical upstream tests for the `cpa_and_roas` model to ensure data quality in marketing analytics calculations.

## Tests Added

### stg_orders
- **Volume anomaly detection**: Monitors daily order volume to catch data pipeline issues
- **Freshness anomaly detection**: Ensures order data is loaded timely

### stg_payments  
- **Volume anomaly detection**: Tracks payment volume patterns to identify data quality issues
- **Freshness anomaly detection**: Monitors payment data timeliness

These tests focus on ensuring the upstream data feeding into CPA and ROAS calculations is consistent, fresh, and reliable.<br><br>Created by: `joost@elementary-data.com`