### PR TITLE
Maayan via Elementary: Add Subscriber to Orders Table

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -61,6 +61,7 @@ models:
       facts based on payments
     meta:
       owner: "Or"
+      subscribers: "@user"
     config:
       tags: ["finance", "sales"]
       elementary:


### PR DESCRIPTION
This PR adds a subscriber to the orders table to ensure notifications are received when data quality issues occur.

## Changes
- Added `subscribers: "@user"` to the orders model metadata in `models/schema.yml`

## Context
The orders table is a critical business asset containing order information with finance and sales tags. Adding a subscriber ensures proper notification when data quality issues are detected.

## Note
If you prefer a different identifier (such as your email address or team name), please update the subscriber field in the schema.yml file accordingly.<br><br>Created by: `maayan+172@elementary-data.com`