### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `orders` model unions `historical_orders` and `real_time_orders`, but these models have inconsistent units:
- `real_time_orders`: amounts are converted to dollars using `cents_to_dollars()` macro
- `historical_orders`: amounts remain in cents (raw values from `op.total_amount`)

This creates a 100x mismatch that propagates through:
1. `customer_conversions.revenue` 
2. `attribution_touches.linear_revenue`
3. `cpa_and_roas.return_on_advertising_spend`

The anomalies are triggering because historical data appears 100x larger than expected.

## Solution
Convert all monetary fields in `historical_orders.sql` from cents to dollars using the `cents_to_dollars()` macro, matching the approach in `real_time_orders.sql`.

## Files Changed
- `models/historical_orders.sql`: Apply `cents_to_dollars()` to all monetary fields
- `models/real_time_orders.sql`: Add documentation comment about units

## Impact
- Fixes ROAS anomaly detection false positives
- Ensures consistent monetary units across the unified orders dataset
- No breaking changes to downstream models (they expect dollar amounts)<br><br>Created by: `joost@elementary-data.com`