### PR TITLE
Michael Myaskovsky via Elementary: Fix unit normalization mismatch in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{% raw %}{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -29,10 +27,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- Convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
@@ -42,4 +41,4 @@ from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+){% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+{% raw %}-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+){% endraw %}


### PR DESCRIPTION
## Problem
The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` outputs them in **dollars**. When these models are unioned in the `orders` model, this creates a 100x unit mismatch that propagates through the data pipeline and causes anomaly tests to fail on the `return_on_advertising_spend` metric.

## Root Cause Analysis
- **historical_orders**: `op.total_amount as amount` (still in cents)
- **real_time_orders**: `{{ cents_to_dollars('amount_cents') }} as amount` (converted to dollars)
- **Impact**: This mismatch flows through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing massive ROAS fluctuations

## Solution
- Convert all monetary fields in `historical_orders` from cents to dollars using the `cents_to_dollars` macro
- Add clarifying comment to `real_time_orders` to document that amounts are in dollars
- Ensures consistent unit normalization across both data sources

## Testing
This fix will:
- Resolve the current `column_anomalies` incident on `cpa_and_roas.return_on_advertising_spend`
- Prevent future unit-related anomalies in financial metrics
- Maintain data consistency across historical and real-time pipelines

Closes incident: 1f6f38ea-e8ef-475b-b957-a8effe32b5b4<br><br>Created by: `michael@elementary-data.com`