### PR TITLE
Michael Myaskovsky via Elementary: Add michael as owner to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -124,7 +124,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend,
       by source, and per day"
     meta:
-      owner: "Or"
+      owner: ["Or", "michael"]
     config:
       tags:
         - "finance"


### PR DESCRIPTION
Adding michael as an additional owner to the cpa_and_roas model alongside the existing owner Or. This will ensure proper ownership and governance of this critical ROAS calculation model.<br><br>Created by: `michael@elementary-data.com`