### PR TITLE
Michael Myaskovsky via Elementary: Fix unit mismatch: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -30,9 +28,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🐛 Bug Fix: Historical Orders Amount Unit Mismatch

### Problem
The `historical_orders` model was storing amounts in **cents** while `real_time_orders` stores amounts in **dollars**. When these models are unioned in the `orders` model, this creates a 100x unit mismatch that propagates through the entire attribution pipeline, causing massive inflation in ROAS calculations and triggering anomaly detection alerts.

### Root Cause
- **historical_orders**: `op.total_amount as amount` (cents, no conversion)
- **real_time_orders**: `{{ cents_to_dollars('amount_cents') }} as amount` (converted to dollars)

### Solution
Updated `historical_orders.sql` to use the same `cents_to_dollars()` macro pattern as `real_time_orders`, ensuring consistent dollar-denominated amounts across both data sources.

### Impact
- ✅ Fixes inflated ROAS calculations in `cpa_and_roas` model
- ✅ Resolves column anomaly test failures on `return_on_advertising_spend`
- ✅ Ensures consistent units across historical and real-time order data
- ✅ Maintains data integrity in marketing attribution pipeline

### Files Changed
- `models/historical_orders.sql`: Convert all monetary amounts from cents to dollars
- `models/real_time_orders.sql`: Add clarifying comment about dollar denomination

### Testing
This change will resolve the ongoing incident on `return_on_advertising_spend` anomaly detection and ensure consistent monetary calculations across the entire attribution pipeline.<br><br>Created by: `michael@elementary-data.com`