### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch causing ROAS anomaly incidents

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted from cents to dollars
 {{
   config(materialized='view')
 }}
@@ -29,10 +30,13 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        {% raw %}
+        -- convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
+        {% endraw %}
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `column_anomalies` test on `RETURN_ON_ADVERTISING_SPEND` has been failing due to a unit normalization mismatch between two data sources in the `orders` model:

- **real_time_orders**: Properly converts cents to dollars 
- **historical_orders**: Keeps amounts in cents (no conversion)

When these are unioned, historical data appears 100x inflated, causing massive ROAS spikes that trigger anomaly detection.

## Root Cause Analysis

Through upstream investigation, I traced the issue through this path:
1. `cpa_and_roas` calculates ROAS from `attribution_revenue`
2. `attribution_touches` uses `revenue` from `customer_conversions` 
3. `customer_conversions` uses `amount` from `orders`
4. `orders` unions `historical_orders` (cents) + `real_time_orders` (dollars)

## Solution

- **historical_orders.sql**: Convert all monetary fields from cents to dollars using the `cents_to_dollars` macro
- **real_time_orders.sql**: Add documentation comment confirming dollar units
- Ensures both data sources use consistent dollar units in the union

## Impact

- **Fixes**: ROAS anomaly incidents (High severity)
- **Prevents**: Incorrect marketing spend decisions based on inflated historical performance  
- **Improves**: Data consistency across all marketing analytics

## Testing

After this change:
- Historical revenue values will be 100x smaller (correct)
- ROAS calculations will be consistent across time periods
- Anomaly tests should pass with normal variance patterns<br><br>Created by: `joost@elementary-data.com`