### PR TITLE
Joost Boonzajer Flaes via Elementary: Add upstream tests for cpa_and_roas staging dependencies

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,15 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warning
+            owner: ["@data-ops"]
+      - elementary.freshness_anomalies:
+          config:
+            severity: warning
+            owner: ["@data-ops"]
     columns:
       - name: order_id
         tests:
@@ -46,6 +55,15 @@ models:
       owner: "Idan"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warning
+            owner: ["@data-ops"]
+      - elementary.freshness_anomalies:
+          config:
+            severity: warning
+            owner: ["@data-ops"]
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
This PR adds upstream test recommendations for the `cpa_and_roas` model's staging dependencies to improve data quality monitoring:

## Added Tests

### stg_orders model
- **Volume anomaly detection**: Monitors for unexpected changes in row count
- **Freshness anomaly detection**: Detects when the table hasn't been updated within expected timeframes

### stg_payments model  
- **Volume anomaly detection**: Monitors for unexpected changes in row count
- **Freshness anomaly detection**: Detects when the table hasn't been updated within expected timeframes

## Why These Tests Matter

These staging layer tests provide early detection of data pipeline issues that could propagate downstream to the `cpa_and_roas` model, affecting cost per acquisition and return on advertising spend calculations. Volume and freshness anomalies at the staging layer can indicate:

- Data pipeline failures or delays
- Upstream source system issues  
- Processing bottlenecks
- Data quality degradation

By catching these issues early in the pipeline, we can maintain data reliability for downstream business metrics.<br><br>Created by: `joost@elementary-data.com`