### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix ROAS unit mismatch: standardize monetary amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{% raw %}{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -30,9 +28,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
@@ -42,4 +40,4 @@ from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+) {% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+{% raw %}-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -50,4 +49,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+) {% endraw %}


### PR DESCRIPTION
## Problem
The `column_anomalies` test on `return_on_advertising_spend` was failing due to a unit mismatch in the underlying data:

- `real_time_orders` converts monetary amounts from cents to dollars using the `cents_to_dollars` macro
- `historical_orders` uses raw amounts in cents without conversion
- When these are unioned in the `orders` model, it creates a 100x difference that propagates through the attribution pipeline to ROAS calculations

## Solution
- **Convert monetary fields in `historical_orders.sql`** from cents to dollars using the `cents_to_dollars` macro to match `real_time_orders`
- **Add clarifying comment in `real_time_orders.sql`** to document that amounts are in dollars
- Ensures consistent dollar amounts across both data sources

## Impact
- Stabilizes ROAS calculations by eliminating the 100x unit mismatch
- Prevents future anomaly test failures caused by this inconsistency
- Maintains data integrity across historical and real-time order data

## Testing
After this change, both `historical_orders` and `real_time_orders` will output monetary amounts in dollars, creating consistent input for downstream models in the attribution pipeline.<br><br>Created by: `joost@elementary-data.com`