### PR TITLE
Michael Myaskovsky via Elementary: Fix unit normalization mismatch in historical_orders amount column

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,23 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}
+    -- convert every monetary field from cents to dollars
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount  -- Amount is now in dollars
+    {% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🐛 Bug Fix: Unit Normalization Mismatch

### Problem
The `historical_orders` model was outputting `amount` in **cents**, while `real_time_orders` outputs `amount` in **dollars**. When these get UNIONed in the `orders` model, historical data appears 100× larger than it should be, causing the ROAS anomaly detection test to fail.

### Root Cause Analysis
Investigation traced the issue through the data lineage:
- `cpa_and_roas.return_on_advertising_spend` ← `attribution_touches.linear_revenue` ← `customer_conversions.revenue` ← `orders.amount`
- `orders` UNIONs `historical_orders` (cents) + `real_time_orders` (dollars)
- This created a 100× mismatch in revenue calculations

### Solution
✅ **historical_orders.sql**: Convert all monetary amounts from cents to dollars using the `cents_to_dollars()` macro
✅ **real_time_orders.sql**: Add clarifying comment about dollar amounts
✅ Maintain consistency with existing code patterns and macro usage

### Testing
- [ ] Run `dbt test` to verify all tests pass
- [ ] Monitor ROAS anomaly detection test for resolution
- [ ] Validate that historical and real-time revenue data now align

### Impact
- Fixes ROAS calculation accuracy
- Ensures consistent monetary units across the data pipeline
- Resolves ongoing anomaly detection false positives

Related incident: `1f6f38ea-e8ef-475b-b957-a8effe32b5b4`<br><br>Created by: `michael@elementary-data.com`