### PR TITLE
Michael Myaskovsky via Elementary: Add additional owner to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -124,7 +124,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend,
       by source, and per day"
     meta:
-      owner: "Or"
+      owner: ["Or", "@user"]
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds an additional owner to the cpa_and_roas model while preserving the existing owner configuration. The model now supports multiple owners for better governance and responsibility sharing.<br><br>Created by: `michael@elementary-data.com`