### PR TITLE
Michael Myaskovsky via Elementary: Fix ROAS anomaly: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,23 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}
+    -- convert every monetary field from cents to dollars
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount  -- Amount is now in dollars
+    {% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Problem
The ROAS (Return on Advertising Spend) anomaly detection test has been failing with 25 consecutive failures due to a **unit normalization mismatch** between `historical_orders` and `real_time_orders` models.

### Root Cause Analysis
- `historical_orders.amount` stores values in **cents** (no conversion)
- `real_time_orders.amount` stores values in **dollars** (converted via `cents_to_dollars` macro)
- When unioned in the `orders` model, this creates a 100x mismatch
- This propagates through: `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`
- ROAS calculations become artificially inflated when historical orders are included

## Solution
- Convert all monetary fields in `historical_orders.sql` from cents to dollars using the `cents_to_dollars` macro
- Add clarifying comment to `real_time_orders.sql` about dollar normalization
- Maintain consistency between both models feeding into the `orders` union

## Files Changed
- `models/historical_orders.sql`: Convert cents to dollars for all monetary fields
- `models/real_time_orders.sql`: Add explanatory comment (no logic changes)

## Testing
After this fix:
- Both `historical_orders` and `real_time_orders` will output amounts in dollars
- ROAS calculations will be consistent across all time periods
- Anomaly detection tests should pass

Resolves incident: column_anomalies test failure on `RETURN_ON_ADVERTISING_SPEND`<br><br>Created by: `michael@elementary-data.com`