### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch in orders models causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `historical_orders` and `real_time_orders` models had inconsistent currency units:
- **historical_orders**: amounts in cents (no conversion)  
- **real_time_orders**: amounts converted to dollars via `cents_to_dollars` macro

When these models are unioned in the `orders` model, this created a **100x scale difference** that propagated through the entire marketing attribution pipeline, causing the `return_on_advertising_spend` column anomaly tests to fail.

## Solution
- ✅ Updated **historical_orders** to use `cents_to_dollars` macro for all monetary fields
- ✅ Added documentation comment to **real_time_orders** for clarity
- ✅ Both models now output consistent dollar amounts

## Impact
- Fixes ongoing ROAS anomaly detection incidents (HIGH severity)
- Ensures accurate marketing attribution calculations
- Maintains data consistency across historical and real-time datasets

## Testing
After deployment:
1. Verify `orders` model produces consistent currency units
2. Confirm `cpa_and_roas` calculations return to normal ranges  
3. Monitor ROAS anomaly tests for resolution<br><br>Created by: `joost@elementary-data.com`