### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit conversion in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,5 +1,4 @@
-{{
-  config(materialized='view')
+{{-config(materialized='view')
 }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
@@ -29,10 +28,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- Convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,5 +1,5 @@
-{{
-  config(materialized='view')
+-- All monetary amounts in this model are in dollars
+{{-config(materialized='view')
 }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}


### PR DESCRIPTION
## Problem

The `historical_orders` model was not converting cent values to dollars, causing a 100× unit mismatch when combined with `real_time_orders` in the `orders` model. This mismatch propagated through the data pipeline and triggered ROAS anomaly alerts.

## Root Cause

- `real_time_orders` correctly converts cents to dollars using the `cents_to_dollars` macro
- `historical_orders` was passing through raw cent values without conversion
- When UNION'd together in `orders`, this created inconsistent units that inflated ROAS calculations

## Solution

- Updated `historical_orders` to use the `cents_to_dollars` macro for all monetary fields
- Added explanatory comment to `real_time_orders` for clarity
- Both models now consistently output monetary values in dollars

## Impact

This fix resolves the HIGH severity column anomaly incident on the `cpa_and_roas.return_on_advertising_spend` metric and ensures accurate marketing performance reporting.

Closes incident: f613d3d2-7901-435f-85ef-6d8054473bec<br><br>Created by: `joost@elementary-data.com`