### PR TITLE
Joost Boonzajer Flaes via Elementary: Change owner from Or to Joost for all models

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -36,7 +36,7 @@ models:
     description: "This is a table that contains all the touch points, by session,
       with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -124,7 +124,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend,
       by source, and per day"
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags:
         - "finance"
@@ -182,7 +182,7 @@ models:
     description: "This table contains information on the ad spend, by source, medium
       and campaign"
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["marketing", "finance"]
       elementary:
@@ -217,7 +217,7 @@ models:
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["marketing"]
       elementary:
@@ -256,7 +256,7 @@ models:
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["marketing", "finance", "pii"]
       elementary:
@@ -278,7 +278,7 @@ models:
     description: "This table contains information on the sessions of all the customers
       and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["marketing", "pii"]
       elementary:

--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -60,7 +60,7 @@ models:
     description: This table has basic information about orders, as well as some derived
       facts based on payments
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["finance", "sales"]
       elementary:
@@ -124,7 +124,7 @@ models:
   - name: returned_orders
     description: This table contains all of the returned orders
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["finance"]
       elementary:
@@ -185,7 +185,7 @@ models:
   - name: lost_orders
     description: This table contains all of the lost orders
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["finance"]
       elementary:
@@ -264,7 +264,7 @@ models:
     description: "Orders loaded from the historical batch datasets (prior to the current
       day). Amount fields are stored in cents."
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["finance", "sales"]
       elementary:
@@ -294,7 +294,7 @@ models:
       Monetary fields have already been converted to dollars via the cents_to_dollars
       macro."
     meta:
-      owner: "Or"
+      owner: "Joost"
     config:
       tags: ["finance", "sales", "real_time"]
       elementary:


### PR DESCRIPTION
This PR updates the owner metadata for all models currently owned by "Or" to be owned by "Joost" instead.

## Models Updated:

### Main schema (models/schema.yml):
- orders
- returned_orders  
- lost_orders
- historical_orders
- real_time_orders

### Marketing schema (models/marketing/schema.yml):
- ads_spend
- attribution_touches
- cpa_and_roas
- marketing_ads
- agg_sessions
- customer_conversions
- sessions

Total: 12 models updated<br><br>Created by: `joost@elementary-data.com`