### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix historical_orders amount unit mismatch (cents vs dollars)

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted from cents to dollars
 {{
   config(materialized='view')
 }}
@@ -32,12 +33,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are already normalized to dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Root Cause
The `historical_orders` model was storing monetary amounts in **cents** while `real_time_orders` was storing them in **dollars**. When unioned in the `orders` model, this created a 100× mismatch that propagated through the attribution pipeline and triggered anomaly alerts on the ROAS metric in `cpa_and_roas`.

## Investigation Trail
1. **cpa_and_roas** - ROAS calculation formula correct
2. **attribution_touches** - Passes through `linear_revenue` from conversions
3. **customer_conversions** - Uses `orders.amount` as revenue
4. **orders** - UNIONs `historical_orders` and `real_time_orders`
5. **real_time_orders** - ✅ Converts cents to dollars: `(amount_cents / 100)`
6. **historical_orders** - ❌ Keeps original cents: `op.total_amount as amount`

## Fix
- **historical_orders.sql**: Convert all monetary fields from cents to dollars using the `cents_to_dollars` macro
- **real_time_orders.sql**: Add explanatory comment for clarity

## Impact
- Fixes the anomaly detection alerts on `return_on_advertising_spend`
- Ensures consistent unit normalization across the attribution pipeline
- Prevents future data quality issues from this unit mismatch

## Testing
After deployment, the ROAS values should normalize and anomaly tests should pass.<br><br>Created by: `joost@elementary-data.com`