### PR TITLE
Joost Boonzajer Flaes via Elementary: Add PII tags to customer and order identifiers

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -45,10 +45,12 @@ models:
       - name: customer_id
         data_type: number
         description: "A unique identifier for a customer"
+        tags: ["pii"]
 
       - name: session_id
         data_type: varchar
         description: "A unique identifier for a session"
+        tags: ["pii"]
 
       - name: started_at
         data_type: timestamp_ntz
@@ -226,10 +228,12 @@ models:
       - name: session_id
         data_type: varchar
         description: "Unique identifier for a session"
+        tags: ["pii"]
 
       - name: customer_id
         data_type: number
         description: "Unique identifier for a customer"
+        tags: ["pii"]
 
       - name: started_at
         data_type: timestamp_ntz
@@ -265,6 +269,7 @@ models:
       - name: customer_id
         data_type: number
         description: "Unique identifier for a customer"
+        tags: ["pii"]
 
       - name: converted_at
         data_type: timestamp_ntz
@@ -287,10 +292,12 @@ models:
       - name: session_id
         data_type: varchar
         description: "Unique identifier for a session"
+        tags: ["pii"]
 
       - name: customer_id
         data_type: number
         description: "Unique identifier for a customer"
+        tags: ["pii"]
 
       - name: started_at
         data_type: timestamp_ntz

--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -15,6 +15,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
+        tags: ["pii"]
         tests:
           - relationships:
               config:
@@ -25,9 +26,11 @@ models:
 
       - name: first_name
         description: Customer's first name. PII.
+        tags: ["pii"]
 
       - name: last_name
         description: Customer's last name. PII.
+        tags: ["pii"]
 
       - name: first_order
         description: Date (UTC) of a customer's first order
@@ -43,6 +46,7 @@ models:
 
       - name: customer_email
         description: Customer's email. PII.
+        tags: ["pii"]
         tests:
           - unique:
               config:
@@ -76,9 +80,11 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tags: ["pii"]
 
       - name: customer_id
         description: Foreign key to the customers table
+        tags: ["pii"]
         tests:
           - relationships:
               config:
@@ -137,9 +143,11 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tags: ["pii"]
 
       - name: customer_id
         description: Foreign key to the customers table
+        tags: ["pii"]
         tests:
           - relationships:
               config:
@@ -197,9 +205,11 @@ models:
       - name: order_id
         description: This is a unique identifier for an order
         data_type: integer
+        tags: ["pii"]
 
       - name: customer_id
         description: Foreign key to the customers table
+        tags: ["pii"]
         tests:
           - relationships:
               config:
@@ -253,6 +263,7 @@ models:
     columns:
       - name: order_id
         description: "Unique identifier for an order"
+        tags: ["pii"]
       - name: sku
         description: "Unique stock-keeping unit for the item"
       - name: quantity
@@ -272,8 +283,10 @@ models:
     columns:
       - name: order_id
         description: "Unique identifier for an order"
+        tags: ["pii"]
       - name: customer_id
         description: "Foreign key to the customers table"
+        tags: ["pii"]
       - name: order_date
         description: "Date (UTC) the order was placed"
       - name: status
@@ -302,8 +315,10 @@ models:
     columns:
       - name: order_id
         description: "Unique identifier for an order"
+        tags: ["pii"]
       - name: customer_id
         description: "Foreign key to the customers table"
+        tags: ["pii"]
       - name: order_date
         description: "Date (UTC) the order was placed"
       - name: status

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -8,6 +8,7 @@ models:
       tags: ["staging", "pii"]
     columns:
       - name: customer_id
+        tags: ["pii"]
         tests:
           - unique:
               config:
@@ -25,10 +26,13 @@ models:
         timestamp_column: "order_date"
     columns:
       - name: order_id
+        tags: ["pii"]
         tests:
           - unique:
               config:
                 severity: warn
+      - name: customer_id
+        tags: ["pii"]
       - name: status
         tests:
           - accepted_values:
@@ -73,6 +77,7 @@ models:
               config:
                 severity: warn
       - name: customer_email
+        tags: ["pii"]
         tests:
           - unique
           - elementary.column_anomalies:


### PR DESCRIPTION
This PR adds PII (Personally Identifiable Information) tags to columns that can identify or trace back to individual customers across multiple models.

## Changes Made

### Main Models (models/schema.yml)
- Added PII tags to `customer_id` columns in: orders, returned_orders, lost_orders, historical_orders, real_time_orders
- Added PII tags to `order_id` columns in: orders, returned_orders, lost_orders, historical_orders, real_time_orders
- Updated `customer_id` in customers model to include PII tag

### Staging Models (models/staging/schema.yml)  
- Added PII tag to `customer_id` column in stg_customers model
- Added PII tags to `customer_id` and `order_id` columns in stg_orders model

### Marketing Models (models/marketing/schema.yml)
- Added PII tags to `customer_id` columns in: attribution_touches, agg_sessions, customer_conversions, sessions
- Added PII tags to `session_id` columns in: attribution_touches, agg_sessions, sessions

## Rationale

These columns contain identifiers that can be used to trace back to individual customers or their behavior patterns:
- `customer_id`: Direct personal identifier linking to specific individuals
- `order_id`: Can identify individual purchasing behavior and link to customers
- `session_id`: Tracks individual user behavior and sessions

Properly tagging these as PII ensures compliance with data privacy regulations and helps with data governance.<br><br>Created by: `joost@elementary-data.com`