### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization issue in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted to dollars to match real_time_orders
 {{
   config(materialized='view')
 }}
@@ -30,9 +31,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🐛 Problem

The `historical_orders` model was not converting monetary amounts from cents to dollars, while `real_time_orders` was correctly applying the conversion. This created a 100x scaling difference when the two datasets are unioned in the `orders` model.

**Impact:**
- ❌ ROAS calculations in `cpa_and_roas` model showing wildly inconsistent values
- ❌ Column anomaly incident: `return_on_advertising_spend` average anomaly (High severity)
- ❌ Dimension anomaly incident on `orders` model
- ❌ Finance dashboards (CAC, LTV) displaying incorrect revenue metrics

## 🔧 Solution

Applied consistent unit normalization in `historical_orders.sql` by:

1. **Converting all monetary fields from cents to dollars** using the `cents_to_dollars()` macro
2. **Added explanatory comment** in `real_time_orders.sql` for clarity
3. **Ensuring both models now produce amounts in the same currency unit**

## 🧪 Root Cause Analysis

**Data Flow:** `historical_orders` + `real_time_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

**Before Fix:**
- `historical_orders.amount`: **$25.00 stored as 2500** (cents, not converted)
- `real_time_orders.amount`: **$25.00 stored as 25.00** (dollars, converted)
- Result: Historical revenue appears 100x higher than real-time revenue

**After Fix:**
- Both models consistently output amounts in **dollars**
- ROAS calculations now use consistent revenue values
- Anomaly detection will stabilize

## ✅ Expected Results

- ✅ Resolves `cpa_and_roas` ROAS column anomaly incident
- ✅ Resolves `orders` dimension anomaly incident  
- ✅ Corrects finance dashboard revenue metrics
- ✅ Ensures data consistency across historical/real-time revenue streams<br><br>Created by: `joost@elementary-data.com`