### PR TITLE
Mika Kerman via Elementary: Assign missing owners to source tables

### DIFF
--- a/jaffle_shop_online/models/marketing/staging/sources.yml
+++ b/jaffle_shop_online/models/marketing/staging/sources.yml
@@ -3,6 +3,8 @@ version: 2
 sources:
   - name: ads
     schema: "{{ target.schema }}"
+    meta:
+      owner: "Or"
     tables:
       - name: stg_google_ads
       - name: stg_facebook_ads
@@ -10,6 +12,8 @@ sources:
 
   - name: sessions
     schema: "{{ target.schema }}"
+    meta:
+      owner: "Or"
     tables:
       - name: stg_website_sessions
       - name: stg_app_sessions

--- a/jaffle_shop_online/models/sources.yml
+++ b/jaffle_shop_online/models/sources.yml
@@ -3,5 +3,7 @@ version: 2
 sources:
   - name: elementary
     schema: jaffle_shop_elementary
+    meta:
+      owner: "Or"
     tables:
       - name: elementary_exposures


### PR DESCRIPTION
This PR assigns owners to source tables that were missing ownership information to improve data governance.

## Changes Made

### Marketing/Ad Sources → Or
- `stg_facebook_ads`
- `stg_google_ads` 
- `stg_instagram_ads`

### Session Sources → Or  
- `stg_app_sessions`
- `stg_website_sessions`

### Elementary Sources → Or
- `elementary_exposures`

## Rationale

These ownership assignments are based on existing ownership patterns:
- **Or** already owns related models like `marketing_ads`, `ads_spend`, `sessions`, and `agg_sessions`
- This creates consistency in ownership for related data assets
- Ensures all source tables have designated owners for accountability

## Impact
- Closes ownership gaps for 6 source tables  
- Improves data governance and accountability
- Aligns with existing ownership patterns in the project<br><br>Created by: `mika@elementary-data.com`