### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted to dollars to match real_time_orders normalization
 {{
   config(materialized='view')
 }}
@@ -29,10 +30,13 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        {% raw %}
+        -- Convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
+        {% endraw %}
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model stores monetary amounts in **cents** while `real_time_orders` converts amounts to **dollars**. When these models are combined via `UNION ALL` in the `orders` model, this creates a 100x magnitude difference that propagates through:

- `orders.amount` → `customer_conversions.revenue` → `attribution_touches.linear_revenue` → `cpa_and_roas.return_on_advertising_spend`

This unit mismatch is causing the `column_anomalies` test on `RETURN_ON_ADVERTISING_SPEND` to fail with HIGH severity.

## Solution

- **historical_orders.sql**: Convert all monetary amounts from cents to dollars using the `cents_to_dollars` macro to match `real_time_orders` normalization
- **real_time_orders.sql**: Add clarifying comment that amounts are in dollars

## Root Cause Evidence

**real_time_orders.sql** (Line 36):
```sql
{{ cents_to_dollars('amount_cents') }} as amount  -- Correctly converts to dollars
```

**historical_orders.sql** (Line 27): 
```sql
op.total_amount as amount  -- Still in cents - ROOT CAUSE
```

## Impact

This fix ensures consistent dollar-denominated amounts across both historical and real-time order data, resolving the anomaly detection failures on downstream ROAS calculations.

Fixes incident: f613d3d2-7901-435f-85ef-6d8054473bec<br><br>Created by: `joost@elementary-data.com`