### PR TITLE
Joost Boonzajer Flaes via Elementary: Change owner from Idan to joost for staging models

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: stg_customers
     meta:
-      owner: "Idan"
+      owner: "joost"
     config:
       tags: ["staging", "pii"]
     columns:
@@ -18,7 +18,7 @@ models:
 
   - name: stg_orders
     meta:
-      owner: "Idan"
+      owner: "joost"
     config:
       tags: ["staging", "finance", "sales"]
       elementary:
@@ -43,7 +43,7 @@ models:
 
   - name: stg_payments
     meta:
-      owner: "Idan"
+      owner: "joost"
     config:
       tags: ["staging", "finance"]
     columns:
@@ -61,7 +61,7 @@ models:
 
   - name: stg_signups
     meta:
-      owner: "Idan"
+      owner: "joost"
     config:
       tags: ["staging", "pii"]
       elementary:


### PR DESCRIPTION
This PR updates the ownership of all staging models from "Idan" to "joost" as requested.

## Changes Made
- Updated `models/staging/schema.yml` to change owner from "Idan" to "joost" for:
  - `stg_customers`
  - `stg_orders`
  - `stg_payments`
  - `stg_signups`

## Impact
- All staging models will now be owned by joost
- No other configuration changes were made
- All existing tests and configurations remain intact<br><br>Created by: `joost@elementary-data.com`