### PR TITLE
Joost Boonzajer Flaes via Elementary: Add upstream data quality tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -76,6 +76,11 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tests:
+          - unique:
+              config:
+                severity: error
+                owner: ["Or"]
 
       - name: customer_id
         description: Foreign key to the customers table
@@ -108,6 +113,25 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
+        tests:
+          - elementary.column_anomalies:
+              config:
+                owner: ["Or"]
+                severity: warning
+              column_anomalies:
+                - average
+              timestamp_column: order_date
+              time_bucket:
+                period: day
+                count: 1
+              training_period:
+                period: day
+                count: 30
+              detection_period:
+                period: day
+                count: 2
+              anomaly_sensitivity: 1.5
+              anomaly_direction: both
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
@@ -310,6 +334,12 @@ models:
         description: '{{ doc("orders_status") }}'
       - name: amount
         description: "Total order amount (AUD) – already converted to dollars"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "<= (select max(price) from {{ ref('raw_products') }})"
+              config:
+                severity: error
+                owner: ["Or"]
       - name: credit_card_amount
         description: "Portion of the order paid with credit card (AUD)"
       - name: coupon_amount

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,29 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            owner: ["Idan"]
+            severity: warning
+          timestamp_column: order_date
+          time_bucket:
+            period: day
+            count: 1
+          training_period:
+            period: day
+            count: 14
+          detection_period:
+            period: day
+            count: 1
+          anomaly_sensitivity: 2
+          anomaly_direction: both
+      - elementary.freshness_anomalies:
+          config:
+            owner: ["Idan"]
+            severity: warning
+          timestamp_column: order_date
+          anomaly_sensitivity: 2
     columns:
       - name: order_id
         tests:


### PR DESCRIPTION
## Summary

This PR adds comprehensive data quality tests for upstream models feeding into the `cpa_and_roas` model to ensure accurate Cost Per Acquisition and Return on Advertising Spend calculations.

## Tests Added

### orders model (3-level upstream)
- **Unique test on order_id**: Prevents duplicate orders from skewing attribution revenue calculations
- **Column anomaly test on amount**: Monitors the amount column for unusual patterns since this value directly feeds ROAS calculations

### real_time_orders model (4-level upstream)  
- **Custom validation test on amount**: Validates that order amounts don't exceed maximum product prices from raw_products table, catching potential data quality issues in real-time ingestion

### stg_orders model (5-level upstream)
- **Volume anomaly test**: Detects unusual changes in row count that could indicate pipeline issues
- **Freshness anomaly test**: Monitors data recency for timely marketing analysis

## Business Impact

These tests help ensure:
- Marketing attribution calculations are accurate and not inflated by duplicate orders
- Financial metrics (CPA/ROAS) are based on validated, reasonable amounts  
- Data pipeline health is monitored to prevent stale data from affecting marketing decisions
- Real-time order data meets business logic constraints

## Testing

All tests follow Elementary best practices and are configured with appropriate severity levels and ownership.<br><br>Created by: `joost@elementary-data.com`