### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization mismatch between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,14 +30,23 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    -- Convert every monetary field from cents to dollars to match real_time_orders
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount  -- Amount is now in dollars
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -50,4 +49,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+)


### PR DESCRIPTION
## Root Cause
The ROAS anomaly detection was failing due to a unit normalization inconsistency between `historical_orders` and `real_time_orders` models:

- **real_time_orders**: Correctly converts amounts from cents to dollars using `cents_to_dollars()` macro
- **historical_orders**: Returns raw amounts in cents without conversion

This 100× mismatch causes massive spikes in ROAS calculations when historical data flows through the attribution pipeline.

## Changes Made
1. **historical_orders.sql**: Applied `cents_to_dollars()` macro to all monetary fields to match real_time_orders format
2. **real_time_orders.sql**: Added clarifying comment about dollar normalization

## Impact
- Fixes ROAS anomaly detection failures
- Ensures consistent monetary units across the entire orders dataset
- Maintains data integrity in downstream attribution and marketing models

## Testing
After this change, the `column_anomalies` test on `return_on_advertising_spend` should pass as the unit inconsistency will be resolved.<br><br>Created by: `joost@elementary-data.com`