### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization in historical_orders model

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -29,10 +29,13 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        {% raw %}
+        -- convert every monetary field and the total
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
+        {% endraw %}
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,6 @@
+{% raw %}
+-- All monetary amounts in this model are in dollars
+{% endraw %}
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `historical_orders` model was not applying the same unit normalization as `real_time_orders`, causing a 100x mismatch in the `amount` column when these models are UNIONed in the `orders` model.

This mismatch propagated upstream to the `cpa_and_roas` model, causing the `return_on_advertising_spend` anomaly detection test to fail consistently.

## Root Cause
- `real_time_orders` uses `cents_to_dollars()` macro to convert all monetary amounts
- `historical_orders` was missing this conversion, keeping amounts in cents
- When UNIONed, this created inconsistent units that skewed ROAS calculations

## Solution
- Applied the `cents_to_dollars()` macro to all monetary fields in `historical_orders`
- Added explanatory comment to `real_time_orders` for clarity
- Both models now consistently output amounts in dollars

## Testing
This fix will resolve the failing anomaly detection tests on the `cpa_and_roas.return_on_advertising_spend` column.<br><br>Created by: `joost@elementary-data.com`