### PR TITLE
Joost Boonzajer Flaes via Elementary: Change ownership from Idan to Joost for staging models

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: stg_customers
     meta:
-      owner: "Idan"
+      owner: "Joost"
     config:
       tags: ["staging", "pii"]
     columns:
@@ -18,7 +18,7 @@ models:
 
   - name: stg_orders
     meta:
-      owner: "Idan"
+      owner: "Joost"
     config:
       tags: ["staging", "finance", "sales"]
       elementary:
@@ -43,7 +43,7 @@ models:
 
   - name: stg_payments
     meta:
-      owner: "Idan"
+      owner: "Joost"
     config:
       tags: ["staging", "finance"]
     columns:
@@ -61,7 +61,7 @@ models:
 
   - name: stg_signups
     meta:
-      owner: "Idan"
+      owner: "Joost"
     config:
       tags: ["staging", "pii"]
       elementary:


### PR DESCRIPTION
## Summary

This PR transfers ownership of all staging models from Idan to Joost to ensure proper stewardship of the data pipeline foundation layer.

## Changes Made

- **stg_customers**: Owner changed from Idan → Joost
- **stg_orders**: Owner changed from Idan → Joost  
- **stg_payments**: Owner changed from Idan → Joost
- **stg_signups**: Owner changed from Idan → Joost

## Impact

- All staging models will now be owned and maintained by Joost
- No changes to test configurations, column definitions, or data transformations
- Downstream models (owned by Or and Maayan) continue to depend on these staging models
- Maintains data quality and pipeline integrity under new ownership

## Files Modified

- `models/staging/schema.yml` - Updated meta.owner field for all 4 staging models

This change ensures proper ownership transfer while maintaining all existing data quality tests and configurations.<br><br>Created by: `joost@elementary-data.com`