### PR TITLE
Joost Boonzajer Flaes via Elementary: Convert individual ownership to team-based ownership across all models

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "Or"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -36,7 +36,7 @@ models:
     description: "This is a table that contains all the touch points, by session,
       with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "Or"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -124,7 +124,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend,
       by source, and per day"
     meta:
-      owner: "Or"
+      owner: "@finance-team"
     config:
       tags:
         - "finance"
@@ -182,7 +182,7 @@ models:
     description: "This table contains information on the ad spend, by source, medium
       and campaign"
     meta:
-      owner: "Or"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance"]
       elementary:
@@ -217,7 +217,7 @@ models:
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
     meta:
-      owner: "Or"
+      owner: "@marketing-team"
     config:
       tags: ["marketing"]
       elementary:
@@ -256,7 +256,7 @@ models:
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
     meta:
-      owner: "Or"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "finance", "pii"]
       elementary:
@@ -278,7 +278,7 @@ models:
     description: "This table contains information on the sessions of all the customers
       and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "Or"
+      owner: "@marketing-team"
     config:
       tags: ["marketing", "pii"]
       elementary:

--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -5,7 +5,7 @@ models:
     description: This table has basic information about a customer, as well as some
       derived facts based on a customer's orders
     meta:
-      owner: "Maayan"
+      owner: "@customer-team"
     config:
       elementary:
         timestamp_column: "signup_date"
@@ -60,7 +60,7 @@ models:
     description: This table has basic information about orders, as well as some derived
       facts based on payments
     meta:
-      owner: "Or"
+      owner: "@sales-team"
     config:
       tags: ["finance", "sales"]
       elementary:
@@ -124,7 +124,7 @@ models:
   - name: returned_orders
     description: This table contains all of the returned orders
     meta:
-      owner: "Or"
+      owner: "@sales-team"
     config:
       tags: ["finance"]
       elementary:
@@ -185,7 +185,7 @@ models:
   - name: lost_orders
     description: This table contains all of the lost orders
     meta:
-      owner: "Or"
+      owner: "@sales-team"
     config:
       tags: ["finance"]
       elementary:
@@ -247,7 +247,7 @@ models:
     description: "Junction table between orders and products, containing the individual
       line items per order."
     meta:
-      owner: "Maayan"
+      owner: "@sales-team"
     config:
       tags: ["sales"]
     columns:
@@ -264,7 +264,7 @@ models:
     description: "Orders loaded from the historical batch datasets (prior to the current
       day). Amount fields are stored in cents."
     meta:
-      owner: "Or"
+      owner: "@finance-team"
     config:
       tags: ["finance", "sales"]
       elementary:
@@ -294,7 +294,7 @@ models:
       Monetary fields have already been converted to dollars via the cents_to_dollars
       macro."
     meta:
-      owner: "Or"
+      owner: "@finance-team"
     config:
       tags: ["finance", "sales", "real_time"]
       elementary:

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: stg_customers
     meta:
-      owner: "Idan"
+      owner: "@customer-team"
     config:
       tags: ["staging", "pii"]
     columns:
@@ -18,7 +18,7 @@ models:
 
   - name: stg_orders
     meta:
-      owner: "Idan"
+      owner: "@sales-team"
     config:
       tags: ["staging", "finance", "sales"]
       elementary:
@@ -43,7 +43,7 @@ models:
 
   - name: stg_payments
     meta:
-      owner: "Idan"
+      owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
     columns:
@@ -61,7 +61,7 @@ models:
 
   - name: stg_signups
     meta:
-      owner: "Idan"
+      owner: "@customer-team"
     config:
       tags: ["staging", "pii"]
       elementary:


### PR DESCRIPTION
## 🏢 Team Ownership Migration

This PR converts all individual model ownership to team-based ownership following a domain-driven approach.

### Changes Made

**Individual owners removed:**
- Maayan → @customer-team, @sales-team
- Or → @sales-team, @finance-team, @marketing-team  
- Idan → @customer-team, @sales-team, @finance-team

**New team structure:**
- **@customer-team**: customers, stg_customers, stg_signups
- **@sales-team**: orders, returned_orders, lost_orders, order_items, stg_orders
- **@finance-team**: historical_orders, real_time_orders, cpa_and_roas, stg_payments
- **@marketing-team**: ads_spend, attribution_touches, marketing_ads, agg_sessions, customer_conversions, sessions

### Files Modified
- `models/schema.yml`
- `models/marketing/schema.yml`
- `models/staging/schema.yml`

All existing test configurations and other metadata preserved.<br><br>Created by: `joost@elementary-data.com`