### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix ROAS anomaly: normalize historical_orders amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% for payment_method in payment_methods -%}
+    {% raw %}{{ cents_to_dollars('{{ payment_method }}_amount') }}{% endraw %} as {{ payment_method }}_amount,
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Problem
The ROAS anomaly detection test has been failing due to a unit normalization mismatch between `historical_orders` and `real_time_orders` models.

**Root Cause:**
- `real_time_orders` correctly converts monetary amounts from cents to dollars using the `cents_to_dollars` macro
- `historical_orders` was using raw `total_amount` values that remain in cents
- When these models union in the `orders` model, this creates a 100x mismatch that propagates through revenue calculations

**Impact:**
This mismatch causes the ROAS (Return on Advertising Spend) metric to show dramatic spikes, triggering anomaly detection alerts.

## Solution
- Normalize all monetary fields in `historical_orders.sql` to dollars using the `cents_to_dollars` macro
- Add documentation comment to `real_time_orders.sql` for clarity
- Ensure both branches of the union use consistent dollar units

## Testing
After this change:
- Both historical and real-time order amounts will be in the same unit (dollars)
- ROAS calculations will be consistent and accurate
- Anomaly detection should stabilize

**Related Incident:** HIGH severity incident on cpa_and_roas model (column_anomalies test on RETURN_ON_ADVERTISING_SPEND)<br><br>Created by: `joost@elementary-data.com`