### PR TITLE
Mika via Elementary: Add Marketing Team as Subscriber to CPA and ROAS Model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "@finance-team"
+      subscribers: "@marketing-team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
## Summary
This PR adds the marketing team as a subscriber to the `cpa_and_roas` model to ensure they receive notifications when data quality issues are resolved.

## Changes
- Added `subscribers: "@marketing-team"` to the `cpa_and_roas` model metadata in `models/marketing/schema.yml`

## Business Impact
The marketing team will now be automatically notified when:
- The current high-severity ROAS anomaly is resolved
- Any future data quality incidents occur or are resolved
- This ensures better coordination between finance (owners) and marketing (key users) teams

## Context
The `cpa_and_roas` model currently has a high-severity anomaly in the RETURN_ON_ADVERTISING_SPEND column that has been acknowledged. Adding the marketing team as subscribers ensures they stay informed about the resolution of this issue and any future incidents affecting this critical marketing metric.<br><br>Created by: `mika+demo@elementary-data.com`