### PR TITLE
Noya Offer via Elementary: Add marketing team as subscribers to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "@finance-team"
+      subscribers: "@marketing-team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds @marketing-team as subscribers to the cpa_and_roas model to ensure the marketing team receives notifications when data issues are resolved or new incidents occur.

The marketing team should be notified about ROAS and CPA metrics since these are critical marketing performance indicators that directly impact their decision-making and campaign optimization efforts.<br><br>Created by: `noya@elementary-data.com`