### PR TITLE
Mika via Elementary: Fix ROAS anomaly: normalize amount units in historical_orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}-- Convert every monetary field from cents to dollars
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount  -- Amount is now in dollars{% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+{% raw %}-- All monetary amounts in this model are in dollars{% endraw %}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Problem
The `return_on_advertising_spend` column anomaly test was failing due to a 100× unit mismatch between data sources:

- `real_time_orders.amount` → properly converted from cents to dollars  
- `historical_orders.amount` → still in cents (no conversion)

This mismatch propagated through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing the ROAS metric to fluctuate wildly and trigger anomaly detection.

## Root Cause Analysis
**Traced through 5 hops of lineage:**
1. `cpa_and_roas` - ROAS = `100.0 * attribution_revenue / total_spend` ✓
2. `attribution_touches` - passes through `linear_revenue` ✓  
3. `customer_conversions` - uses `orders.amount` as `revenue` ✓
4. `orders` - UNIONs `historical_orders` + `real_time_orders` ⚠️
5. **Unit mismatch found**: historical (cents) vs real-time (dollars)

## Solution
- **historical_orders.sql**: Convert all monetary fields from cents to dollars using the existing `cents_to_dollars` macro
- **real_time_orders.sql**: Add explanatory comment (no code changes needed)

## Impact
- ✅ Fixes ROAS anomaly detection false positives
- ✅ Ensures consistent monetary units across the entire pipeline  
- ✅ Prevents similar unit-related data quality issues

## Testing
After deployment, the `column_anomalies` test on `return_on_advertising_spend` should stabilize and stop triggering false anomalies.<br><br>Created by: `mika+demo@elementary-data.com`