### PR TITLE
Mika via Elementary: Fix unit normalization: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are normalized to dollars
 {{
   config(materialized='view')
 }}
@@ -30,9 +31,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `cpa_and_roas` model's ROAS anomaly detection is triggering due to a unit normalization mismatch between historical and real-time order data:

- **historical_orders**: Returns monetary amounts in **cents** (no conversion)
- **real_time_orders**: Returns monetary amounts in **dollars** (converts cents to dollars)

This 100x difference propagates through the revenue calculations and causes significant deviations in the ROAS metric.

## Root Cause Analysis
Traced through the data lineage:
1. `cpa_and_roas` calculates ROAS using `attribution_revenue / ads_spend`
2. `attribution_touches` passes through `linear_revenue` from `customer_conversions`
3. `customer_conversions` uses `orders.amount` as revenue
4. `orders` unions `historical_orders` and `real_time_orders`
5. **Issue**: `historical_orders.amount` is in cents, `real_time_orders.amount` is in dollars

## Solution
- **historical_orders.sql**: Convert all monetary fields from cents to dollars using the `cents_to_dollars` macro
- **real_time_orders.sql**: Add documentation comment clarifying that amounts are in dollars
- Ensures both order sources output consistent dollar-denominated amounts

## Testing
- Existing tests will validate the model continues to compile and execute
- The ROAS anomaly should resolve once consistent units flow through the pipeline
- No breaking changes to downstream consumers as the logical values remain correct<br><br>Created by: `mika+demo@elementary-data.com`