### PR TITLE
Noya Offer via Elementary: Fix historical_orders unit mismatch causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are now normalized to dollars (converted from cents)
 {{
   config(materialized='view')
 }}
@@ -29,10 +30,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- Convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `column_anomalies` test on `return_on_advertising_spend` in the `cpa_and_roas` model has been failing due to a unit normalization mismatch between historical and real-time order data.

## Root Cause Analysis
Through systematic investigation, I found that:

1. **real_time_orders** properly converts amounts from cents to dollars using `{{ cents_to_dollars() }}`
2. **historical_orders** was outputting amounts still in cents (no conversion)
3. When these are unioned in the `orders` model, it creates a 100× mismatch
4. This propagates through `customer_conversions` → `attribution_touches` → `cpa_and_roas`
5. The ROAS calculation becomes inconsistent based on the mix of historical vs real-time data

## Solution
- ✅ Convert all monetary fields in `historical_orders` from cents to dollars using the `cents_to_dollars` macro
- ✅ Add explanatory comments to both models for future maintainability
- ✅ Ensure both branches of the `orders` union now output consistent dollar amounts

## Impact
- Resolves the ROAS anomaly detection failures
- Ensures accurate financial metrics across all downstream models
- Prevents similar unit mismatch issues in the future

## Testing
After deployment, the `return_on_advertising_spend` anomaly test should pass consistently, and ROAS values should be stable and accurate.<br><br>Created by: `noya@elementary-data.com`