### PR TITLE
Maayan via Elementary: Add marketing-team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "@finance-team"
+      subscribers: "@marketing-team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the `cpa_and_roas` model to ensure they receive notifications when the current data quality issues are resolved.

## Changes Made
- Added `subscribers: "@marketing-team"` to the `cpa_and_roas` model in `models/marketing/schema.yml`

## Background
The `cpa_and_roas` model currently has two active incidents:
- Volume Anomalies (Open, Normal severity)
- Column anomalies on RETURN_ON_ADVERTISING_SPEND (Acknowledged, High severity)

By adding the marketing team as subscribers, they will be notified when these incidents are resolved, ensuring better visibility into the health of this critical marketing metric.

## Impact
- Marketing team will receive notifications about incident status changes for this model
- No functional changes to the model or its data processing
- Finance team remains as the owner of the model<br><br>Created by: `maayan+172@elementary-data.com`