### PR TITLE
Maayan via Elementary: Fix unit normalization mismatch causing ROAS anomaly failures

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -29,10 +29,13 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        {% raw %}
+        -- convert every monetary field and the total
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
+        {% endraw %}
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `column_anomalies` test on `return_on_advertising_spend` has been failing due to a unit normalization mismatch between historical and real-time order data:

- `historical_orders.amount` remained in **cents** 
- `real_time_orders.amount` was properly converted to **dollars**

This 100× discrepancy propagated through the revenue calculations, causing the ROAS metric to show anomalous spikes/drops that triggered the anomaly detection test.

## Root Cause Analysis
| Model | Amount Field | Unit | Issue |
|-------|-------------|------|-------|
| `historical_orders` | `op.total_amount as amount` | cents | ❌ No conversion |
| `real_time_orders` | `cents_to_dollars('amount_cents') as amount` | dollars | ✅ Properly converted |

## Solution
- Convert all monetary fields in `historical_orders` from cents to dollars using the existing `cents_to_dollars` macro
- Add clarifying comment to `real_time_orders` about dollar denomination
- Ensures consistent units in the `orders` union downstream

## Impact
- Resolves ROAS anomaly detection failures
- Prevents future revenue calculation discrepancies  
- Maintains data consistency across historical and real-time order streams

## Testing
After deployment, the `column_anomalies` test on `return_on_advertising_spend` should pass once the next dbt run completes.<br><br>Created by: `maayan+172@elementary-data.com`