### PR TITLE
Dev RND via Elementary: Fix unit mismatch in historical_orders: convert cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,14 +30,25 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}
+    -- Convert all monetary fields from cents to dollars for consistency with real_time_orders
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
+    {% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -50,4 +49,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+)


### PR DESCRIPTION
## Problem
The `historical_orders` model was storing monetary amounts in **cents**, while `real_time_orders` stores them in **dollars**. This created a 100x mismatch when the two models are unioned in the `orders` model, causing downstream anomalies in the ROAS calculations.

## Root Cause
- **historical_orders**: amounts stored as `op.total_amount as amount` (cents)
- **real_time_orders**: amounts converted using `cents_to_dollars()` macro (dollars)

## Solution
- Convert all monetary fields in `historical_orders` using the existing `cents_to_dollars()` macro
- Add clarifying comment to `real_time_orders` about unit consistency
- Ensure both models output amounts in dollars for proper union compatibility

## Impact
- Fixes anomaly detection failures on `return_on_advertising_spend` column
- Ensures accurate ROAS and CPA calculations for the finance team
- Prevents incorrect marketing ROI metrics that could impact advertising spend decisions

## Testing
After this change, the `column_anomalies` tests on the `cpa_and_roas` model should pass, as the historical and real-time data will have consistent units.<br><br>Created by: `dev@elementary-data.com`