### PR TITLE
Maayan via Elementary: Fix unit normalization mismatch in historical_orders causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model stores monetary amounts in **cents**, while `real_time_orders` converts amounts to **dollars**. When these models are unioned in the `orders` model, this creates a 100x unit mismatch that propagates through the entire data pipeline, causing anomalies in the ROAS calculation.

## Root Cause Analysis

The ROAS anomaly test failure was traced through the data lineage:
- `cpa_and_roas.return_on_advertising_spend` uses revenue data that flows from `orders.amount`
- `orders` unions data from both `historical_orders` and `real_time_orders` 
- `historical_orders.amount` = raw cents (no conversion)
- `real_time_orders.amount` = cents converted to dollars via `cents_to_dollars` macro

This inconsistency causes ROAS values to appear inflated when recent data (real-time orders) dominates the calculation.

## Solution

- **historical_orders.sql**: Convert all monetary fields from cents to dollars using the `cents_to_dollars` macro
- **real_time_orders.sql**: Add clarifying comment that amounts are in dollars

## Impact

This fix will:
- ✅ Resolve the ROAS anomaly test failures
- ✅ Ensure consistent unit normalization across the entire orders pipeline
- ✅ Prevent similar unit mismatch issues in downstream calculations

## Testing

After deployment:
- Monitor the `column_anomalies` test on `cpa_and_roas.return_on_advertising_spend`
- Verify ROAS values are consistent across historical and recent time periods<br><br>Created by: `maayan+172@elementary-data.com`