### PR TITLE
Maayan via Elementary: Update owners for cpa_and_roas and upstream dependencies

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "@marketing-team"
+      owner: "@de-engineering-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -36,7 +36,7 @@ models:
     description: "This is a table that contains all the touch points, by session,
       with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "@marketing-team"
+      owner: "@de-engineering-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -124,7 +124,7 @@ models:
     description: "This table contains the cost per acquisition and return on ad spend,
       by source, and per day"
     meta:
-      owner: "@finance-team"
+      owner: "@de-engineering-team"
     config:
       tags:
         - "finance"
@@ -182,7 +182,7 @@ models:
     description: "This table contains information on the ad spend, by source, medium
       and campaign"
     meta:
-      owner: "@marketing-team"
+      owner: "@de-engineering-team"
     config:
       tags: ["marketing", "finance"]
       elementary:
@@ -217,7 +217,7 @@ models:
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
     meta:
-      owner: "@marketing-team"
+      owner: "@de-engineering-team"
     config:
       tags: ["marketing"]
       elementary:
@@ -256,7 +256,7 @@ models:
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
     meta:
-      owner: "@marketing-team"
+      owner: "@de-engineering-team"
     config:
       tags: ["marketing", "finance", "pii"]
       elementary:
@@ -278,7 +278,7 @@ models:
     description: "This table contains information on the sessions of all the customers
       and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "@marketing-team"
+      owner: "@de-engineering-team"
     config:
       tags: ["marketing", "pii"]
       elementary:

--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -60,7 +60,7 @@ models:
     description: This table has basic information about orders, as well as some derived
       facts based on payments
     meta:
-      owner: "@sales-team"
+      owner: "@de-engineering-team"
     config:
       tags: ["finance", "sales"]
       elementary:


### PR DESCRIPTION
This PR updates the ownership of the cpa_and_roas model and all its upstream dependencies from their current owners to 'de-engineering-team'.

## Changes Made:

### models/marketing/schema.yml
- **cpa_and_roas**: @finance-team → @de-engineering-team
- **ads_spend**: @marketing-team → @de-engineering-team 
- **attribution_touches**: @marketing-team → @de-engineering-team
- **sessions**: @marketing-team → @de-engineering-team
- **customer_conversions**: @marketing-team → @de-engineering-team
- **marketing_ads**: @marketing-team → @de-engineering-team
- **agg_sessions**: @marketing-team → @de-engineering-team

### models/schema.yml
- **orders**: @sales-team → @de-engineering-team

## Impact:
This change transfers ownership responsibility for the cpa_and_roas model and its entire upstream dependency chain to the de-engineering-team, ensuring consistent ownership and responsibility for the complete data lineage.<br><br>Created by: `maayan+172@elementary-data.com`