### PR TITLE
Mika via Elementary: Fix ROAS anomaly: Normalize amount units between historical and real-time orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,23 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}
+    -- convert every monetary field and the total
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount  -- Amount is now in dollars
+    {% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Problem
The column anomalies test on `return_on_advertising_spend` in the `cpa_and_roas` model was failing due to a unit normalization mismatch between historical and real-time order data.

## Root Cause
- `real_time_orders` converts amounts from cents to dollars using the `cents_to_dollars` macro
- `historical_orders` leaves amounts in cents without conversion
- When these datasets are combined via UNION in the `orders` model, historical revenue appears 100x larger than real-time revenue
- This 100x discrepancy propagates through the entire ROAS calculation, triggering anomaly detection

## Solution
- Update `historical_orders.sql` to convert all monetary amounts from cents to dollars using the existing `cents_to_dollars` macro
- Add documentation comment to `real_time_orders.sql` to clarify that amounts are in dollars
- This ensures consistent unit normalization across both data sources

## Impact
- Fixes the ROAS anomaly detection issue
- Ensures accurate financial reporting and marketing analytics
- Maintains consistency in the orders model schema<br><br>Created by: `mika+demo@elementary-data.com`