### PR TITLE
Maayan via Elementary: Fix unit normalization mismatch in historical_orders causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted to dollars to match real_time_orders
 {{
   config(materialized='view')
 }}
@@ -30,9 +31,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🎯 Problem
The `return_on_advertising_spend` anomaly detection test has been failing due to a **unit normalization mismatch** between `historical_orders` and `real_time_orders`:

- **real_time_orders**: Correctly converts amounts from cents to dollars using `cents_to_dollars()` macro
- **historical_orders**: Keeps amounts in cents without conversion

This creates a 100× magnitude difference in revenue data that propagates through the entire marketing attribution pipeline, causing massive spikes in ROAS calculations.

## 🛠️ Solution
- Convert all monetary fields in `historical_orders` from cents to dollars using the `cents_to_dollars()` macro
- Add clarifying comments to both models about unit normalization
- Ensure consistent dollar-denominated amounts throughout the orders pipeline

## 🔍 Root Cause Analysis
The issue traces through this path:
`historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

When ROAS is calculated as `100.0 * attribution_revenue / spend`, historical orders contribute revenue values 100× larger than expected, triggering anomaly detection.

## ✅ Testing
After this fix:
- Both `historical_orders` and `real_time_orders` will output amounts in consistent dollar units
- The `return_on_advertising_spend` anomaly should resolve
- ROAS calculations will be accurate across the entire date range<br><br>Created by: `maayan+172@elementary-data.com`