### PR TITLE
Noya Offer via Elementary: Fix unit mismatch between historical and real-time orders causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -29,10 +29,13 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        {% raw %}
+        -- convert every monetary field and the total
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
+        {% endraw %}
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `column_anomalies` test on `return_on_advertising_spend` was failing because of a unit mismatch between historical and real-time order data.

## Root Cause
- **historical_orders**: Used `total_amount` directly without converting from cents to dollars
- **real_time_orders**: Correctly converted amounts from cents to dollars using `cents_to_dollars()` macro
- When these models were unioned in the `orders` model, historical data was 100x larger, inflating ROAS calculations

## Solution
- Updated `historical_orders.sql` to apply `cents_to_dollars()` macro to all monetary fields
- Added explanatory comment to `real_time_orders.sql` for clarity
- Both models now consistently output amounts in dollars

## Impact
- Fixes the ROAS anomaly detection incident
- Ensures data consistency across the entire downstream lineage (customer_conversions → attribution_touches → cpa_and_roas)
- Prevents future incidents from similar unit mismatches

## Testing
After deployment, the ROAS metrics should return to normal ranges and the column anomaly tests should pass.<br><br>Created by: `noya@elementary-data.com`