### PR TITLE
Dev RND via Elementary: Fix unit mismatch: Convert cents to dollars in historical_orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted to dollars for consistency
 {{
   config(materialized='view')
 }}
@@ -32,12 +33,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% for payment_method in payment_methods -%}
+    {% raw %}{{ cents_to_dollars('{{ payment_method }}_amount') }}{% endraw %} as {{ payment_method }}_amount,
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🔧 Fix: Unit Mismatch in Historical Orders

**Root Cause:** The `historical_orders` model was returning monetary amounts in **cents** while `real_time_orders` properly converts to **dollars**. This created a 100x discrepancy when these models are unioned in the `orders` model, causing massive ROAS anomalies.

### Changes Made:
- ✅ Convert all monetary fields from cents to dollars using the `cents_to_dollars()` macro
- ✅ Match the exact normalization pattern used in `real_time_orders.sql`
- ✅ Add explanatory comment about dollar normalization

### Impact:
- **Fixes** HIGH severity incident on `column_anomalies` test for `RETURN_ON_ADVERTISING_SPEND`
- **Prevents** future anomaly false positives caused by unit inconsistencies
- **Ensures** data consistency across historical and real-time order datasets

### Testing:
After deployment, the ROAS values should stabilize and the anomaly detection incident should resolve automatically once the test passes consistently.<br><br>Created by: `dev@elementary-data.com`