### PR TITLE
Noya Offer via Elementary: Fix ROAS anomaly: normalize historical_orders amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,14 +30,22 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% raw %}{% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}{% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -50,4 +49,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+)


### PR DESCRIPTION
## 🐛 Issue
The `column_anomalies` test on `return_on_advertising_spend` in the `cpa_and_roas` model has been failing due to a unit normalization mismatch in the underlying data.

## 🔍 Root Cause Analysis
After tracing the lineage upstream, I found that:

1. **cpa_and_roas** calculates ROAS using revenue from the `orders` model
2. **orders** unions `historical_orders` and `real_time_orders`
3. **real_time_orders** converts amounts from cents to dollars using `cents_to_dollars` macro
4. **historical_orders** was NOT converting amounts, leaving them in cents

This created a **100× unit mismatch** where historical orders had amounts 100× larger than real-time orders, causing the ROAS calculation to spike dramatically when historical data was included.

## ✅ Solution
- **historical_orders.sql**: Convert all monetary fields from cents to dollars using the `cents_to_dollars` macro to match `real_time_orders`
- **real_time_orders.sql**: Add explanatory comment about units for clarity

## 🧪 Impact
This fix will:
- Resolve the ROAS anomaly test failures
- Ensure consistent monetary units across the entire data pipeline
- Prevent similar unit mismatch issues in downstream models

## 📊 Business Impact
- **High** - The incident affects the critical `cpa_and_roas` model used by the @finance-team
- Fixes incorrect ROAS calculations that could lead to poor marketing investment decisions<br><br>Created by: `noya@elementary-data.com`