### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch in orders models causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}{{ cents_to_dollars('amount') }} as amount,{% endraw %}
+    {% for payment_method in payment_methods -%}
+    {% raw %}{{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,{% endraw %}
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `cpa_and_roas` model's ROAS anomaly detection was failing due to a **100× unit mismatch** between historical and real-time order data:

- `historical_orders.amount` was in **cents** (e.g., 123400)
- `real_time_orders.amount` was in **dollars** (e.g., 1234.00)

When combined via `UNION ALL` in the `orders` model, this created massive spikes in revenue calculations that propagated up through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, triggering the anomaly detection.

## Solution

- **models/historical_orders.sql**: Apply `cents_to_dollars()` macro to all monetary fields for consistency
- **models/real_time_orders.sql**: Add explanatory comment about dollar normalization

## Impact

This fix will:
- ✅ Resolve the ROAS anomaly detection failures
- ✅ Ensure consistent monetary units across all order data
- ✅ Prevent future unit mismatch issues in financial calculations

## Testing

After merging, the `column_anomalies` test on `return_on_advertising_spend` should return to normal ranges.<br><br>Created by: `joost@elementary-data.com`