### PR TITLE
Mika via Elementary: Fix ROAS anomaly: normalize historical_orders monetary units to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,23 +1,23 @@
-{{
+{% raw %}{{{% endraw %}
   config(materialized='view')
-}}
+{% raw %}}}{% endraw %}
 
-{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
+{% raw %}{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}{% endraw %}
 
 with orders as (
-    select * from {{ ref('stg_orders') }}
+    select * from {% raw %}{{ ref('stg_orders') }}{% endraw %}
 ),
 
 payments as (
-    select * from {{ ref('stg_payments') }}
+    select * from {% raw %}{{ ref('stg_payments') }}{% endraw %}
 ),
 
 order_payments as (
     select
         order_id,
-        {% for payment_method in payment_methods -%}
-        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,
-        {% endfor -%}
+        {% raw %}{% for payment_method in payment_methods -%}{% endraw %}
+        sum(case when payment_method = '{% raw %}{{ payment_method }}{% endraw %}' then amount else 0 end) as {% raw %}{{ payment_method }}{% endraw %}_amount,
+        {% raw %}{% endfor -%}{% endraw %}
         sum(amount) as total_amount
     from payments
     group by order_id
@@ -29,15 +29,23 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
-        {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
-        {% endfor -%}
-        op.total_amount    as amount
+        {% raw %}{% for payment_method in payment_methods -%}{% endraw %}
+        op.{% raw %}{{ payment_method }}{% endraw %}_amount,
+        {% raw %}{% endfor -%}{% endraw %}
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% raw %}{% for payment_method in payment_methods -%}{% endraw %}
+    {% raw %}{{ cents_to_dollars(payment_method + '_amount') }}{% endraw %} as {% raw %}{{ payment_method }}{% endraw %}_amount,
+    {% raw %}{% endfor -%}{% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,23 +1,24 @@
-{{
+-- All monetary amounts in this model are normalized to dollars
+{% raw %}{{{% endraw %}
   config(materialized='view')
-}}
+{% raw %}}}{% endraw %}
 
-{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
+{% raw %}{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}{% endraw %}
 
 with orders as (
-    select * from {{ ref('stg_orders') }}
+    select * from {% raw %}{{ ref('stg_orders') }}{% endraw %}
 ),
 
 payments as (
-    select * from {{ ref('stg_payments') }}
+    select * from {% raw %}{{ ref('stg_payments') }}{% endraw %}
 ),
 
 order_payments as (
     select
         order_id,
-        {% for payment_method in payment_methods -%}
-        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,
-        {% endfor -%}
+        {% raw %}{% for payment_method in payment_methods -%}{% endraw %}
+        sum(case when payment_method = '{% raw %}{{ payment_method }}{% endraw %}' then amount else 0 end) as {% raw %}{{ payment_method }}{% endraw %}_amount,
+        {% raw %}{% endfor -%}{% endraw %}
         sum(amount) as total_amount
     from payments
     group by order_id
@@ -29,9 +30,9 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
-        {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
-        {% endfor -%}
+        {% raw %}{% for payment_method in payment_methods -%}{% endraw %}
+        op.{% raw %}{{ payment_method }}{% endraw %}_amount,
+        {% raw %}{% endfor -%}{% endraw %}
         op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
@@ -42,11 +43,11 @@ select
     customer_id,
     order_date,
     status,
-    {{ cents_to_dollars('amount_cents') }} as amount,
-    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
-    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
-    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
-    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% raw %}{{ cents_to_dollars('bank_transfer_amount') }}{% endraw %} as bank_transfer_amount,
+    {% raw %}{{ cents_to_dollars('coupon_amount') }}{% endraw %} as coupon_amount,
+    {% raw %}{{ cents_to_dollars('credit_card_amount') }}{% endraw %} as credit_card_amount,
+    {% raw %}{{ cents_to_dollars('gift_card_amount') }}{% endraw %} as gift_card_amount
 from final
 where date(order_date) = (
     select date(max(order_date)) from final


### PR DESCRIPTION
## 🔧 Problem

The `column_anomalies` test on `return_on_advertising_spend` in the `cpa_and_roas` model was failing due to a **unit normalization mismatch** between two data sources:

- **real_time_orders**: correctly converts amounts from cents to dollars
- **historical_orders**: uses raw amounts still in cents (100x larger values)

This created a dramatic inconsistency in ROAS calculations when the `orders` model unions these two sources.

## 📊 Root Cause Analysis

| Model | Amount Field | Normalization Status |
|-------|--------------|---------------------|
| `real_time_orders` | `(amount_cents / 100)` | ✅ Dollars |
| `historical_orders` | `total_amount as amount` | ❌ Cents |
| `orders` (union) | Inconsistent units | 🚨 **100x mismatch** |

## 🛠️ Solution

1. **Standardize historical_orders**: Convert all monetary fields from cents to dollars using the `cents_to_dollars` macro
2. **Improve code consistency**: Both models now use `amount_cents` as intermediate column name  
3. **Add documentation**: Clarify unit expectations in real_time_orders

## ✅ Impact

- Resolves ROAS anomaly test failures
- Ensures consistent dollar-denominated values across all marketing analytics
- Prevents future unit-related data quality issues
- Maintains backward compatibility (same column names in output)

## 🧪 Testing

This change will:
- Fix the failing `column_anomalies` test on `return_on_advertising_spend`
- Maintain the same schema structure for downstream consumers
- Provide consistent monetary values for accurate ROAS calculations

/cc @finance-team<br><br>Created by: `mika+demo@elementary-data.com`