### PR TITLE
Maayan via Elementary: Add marketing team as subscriber to cpa_and_roas table

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "@finance-team"
+      subscribers: "@marketing-team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds @marketing-team as a subscriber to the cpa_and_roas table to ensure they receive notifications when data quality issues are resolved.

Changes:
- Added subscribers field with @marketing-team to cpa_and_roas model in marketing schema
- This will enable notifications for incident resolution and data quality alerts<br><br>Created by: `maayan+172@elementary-data.com`