### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix ROAS anomaly: normalize historical_orders amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,22 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
+    {% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🚨 Issue
The `return_on_advertising_spend` column anomaly test has been failing due to a **unit normalization mismatch** between `historical_orders` and `real_time_orders` models.

## 🔍 Root Cause
- `real_time_orders.amount`: ✅ Converted to dollars via `cents_to_dollars()` macro
- `historical_orders.amount`: ❌ Left in cents (100x larger values)
- This creates a magnitude difference that propagates through the ROAS calculation

## 🛠️ Solution  
- Convert `historical_orders.amount_cents` to dollars using the same `cents_to_dollars()` macro
- Apply consistent unit conversion to all payment method amounts
- Add clarifying comment to `real_time_orders.sql`

## ✅ Expected Impact
- Resolves the ongoing ROAS anomaly incident
- Ensures consistent dollar amounts across the orders UNION
- Maintains data integrity for downstream marketing analytics

## 🧪 Testing
After this change, both branches of the `orders` model will use consistent dollar amounts, eliminating the 100x variance in the ROAS calculation.<br><br>Created by: `joost@elementary-data.com`