### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}
@@ -32,12 +33,22 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {% endraw %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `column_anomalies` test on `return_on_advertising_spend` in the `cpa_and_roas` model has been failing due to a **unit normalization mismatch** between `historical_orders` and `real_time_orders`.

**Root Cause:**
- `real_time_orders`: ✅ Converts amounts from cents to dollars using `cents_to_dollars()` macro
- `historical_orders`: ❌ Leaves amounts in cents (no conversion)

This 100× difference in the `orders` union flows upstream through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing massive ROAS calculation anomalies.

## Solution
- **Fix:** Convert `historical_orders` amounts from cents to dollars to match `real_time_orders` 
- **Documentation:** Add comment clarifying that all monetary amounts are in dollars
- **Consistency:** Both models now use the same `cents_to_dollars()` macro

## Testing
After this change:
- Historical revenue values will be 1/100th of current values (correct normalization)
- ROAS calculations will be consistent across time periods
- The anomaly test should stabilize within the normal range

This resolves incident: `column_anomalies` on `return_on_advertising_spend`<br><br>Created by: `joost@elementary-data.com`