### PR TITLE
Maayan via Elementary: Fix unit normalization mismatch in historical_orders causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% raw %}{{ cents_to_dollars('bank_transfer_amount') }}{% endraw %} as bank_transfer_amount,
+    {% raw %}{{ cents_to_dollars('coupon_amount') }}{% endraw %} as coupon_amount,
+    {% raw %}{{ cents_to_dollars('credit_card_amount') }}{% endraw %} as credit_card_amount,
+    {% raw %}{{ cents_to_dollars('gift_card_amount') }}{% endraw %} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The ROAS anomaly detection test was failing because of a unit normalization mismatch between `historical_orders` and `real_time_orders` models:

- **real_time_orders**: Properly converts amounts from cents to dollars using `cents_to_dollars()` macro
- **historical_orders**: Keeps amounts in cents without conversion

When these models are unioned in the `orders` model, historical data appears 100x larger than real-time data, causing massive spikes in ROAS calculations.

## Solution
- Apply the same `cents_to_dollars()` macro to all monetary fields in `historical_orders`
- Rename `total_amount` to `amount_cents` for consistency 
- Add documentation comment to `real_time_orders`

## Impact
This fix will:
- ✅ Resolve the ongoing ROAS anomaly incident
- ✅ Ensure consistent unit normalization across all order data
- ✅ Prevent future anomalies from this data quality issue

## Testing
After this change, both models will output amounts in dollars, eliminating the 100x scale difference that was triggering the anomaly detection.

Resolves incident: `2924da99-a790-4dcb-b92a-5f9571d1fdce`<br><br>Created by: `maayan+172@elementary-data.com`