### PR TITLE
Maayan via Elementary: Add upstream data quality tests for cpa_and_roas lineage

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,35 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+            owner: ["@sales-team"]
+          timestamp_column: "order_date"
+          time_bucket:
+            period: day
+            count: 1
+          training_period:
+            period: day
+            count: 14
+          detection_period:
+            period: day
+            count: 2
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
+            owner: ["@sales-team"]
+          timestamp_column: "order_date"
+          time_bucket:
+            period: day
+            count: 1
+          training_period:
+            period: day
+            count: 14
+          detection_period:
+            period: day
+            count: 2
     columns:
       - name: order_id
         tests:
@@ -46,6 +75,33 @@ models:
       owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+            owner: ["@finance-team"]
+          time_bucket:
+            period: day
+            count: 1
+          training_period:
+            period: day
+            count: 14
+          detection_period:
+            period: day
+            count: 2
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
+            owner: ["@finance-team"]
+          time_bucket:
+            period: day
+            count: 1
+          training_period:
+            period: day
+            count: 14
+          detection_period:
+            period: day
+            count: 2
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
## Summary
This PR adds comprehensive data quality tests to the upstream staging models that feed into the `cpa_and_roas` model calculations. These tests will help ensure the reliability of Cost Per Acquisition and Return on Advertising Spend metrics by monitoring data quality at critical upstream points.

## Changes Made
### stg_orders model
- **Volume anomaly test**: Detects unusual changes in order volume that could indicate data pipeline issues
- **Freshness anomaly test**: Monitors for delays in order data updates that could impact downstream calculations

### stg_payments model  
- **Volume anomaly test**: Monitors payment record volume for anomalies that could affect revenue calculations
- **Freshness anomaly test**: Ensures payment data is being updated in a timely manner for accurate financial reporting

## Test Configuration
- All tests configured with `severity: warn` to maintain pipeline stability while providing visibility
- Training period: 14 days for reliable baseline establishment
- Detection period: 2 days for timely anomaly detection
- Daily time buckets for appropriate granularity

## Business Impact
These tests will help maintain trust in marketing performance metrics by:
- Preventing downstream calculation errors from data quality issues
- Providing early warning of data pipeline problems
- Ensuring timely data updates for accurate reporting

The tests focus specifically on the staging models that are critical to the `cpa_and_roas` model's data quality, providing comprehensive monitoring without overwhelming the testing suite.<br><br>Created by: `maayan+172@elementary-data.com`