### PR TITLE
Maayan via Elementary: Fix unit normalization mismatch causing ROAS anomalies

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- Fix: Convert cents to dollars to match real_time_orders unit normalization
 {{
   config(materialized='view')
 }}
@@ -29,10 +30,13 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        {% raw %}
+        -- Convert all monetary fields from cents to dollars to match real_time_orders
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
+        {% endraw %}
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\nThe `cpa_and_roas` model has been experiencing ROAS anomalies due to a unit normalization mismatch in the `orders` model. The issue stems from inconsistent monetary units between `historical_orders` and `real_time_orders`:\n\n- **historical_orders**: monetary amounts stored in **cents** (no conversion)\n- **real_time_orders**: monetary amounts converted to **dollars** via `cents_to_dollars()` macro\n\nWhen these models are unioned in the `orders` model, a 100× discrepancy occurs, causing massive ROAS spikes when historical order data is processed.\n\n## Root Cause Analysis\n\n**Investigation Path:**\n1. `cpa_and_roas` → ROAS formula correct ✅\n2. `attribution_touches` → passes through linear_revenue ✅  \n3. `customer_conversions` → uses orders.amount as revenue ✅\n4. `orders` → **UNION of historical + real-time** ⚠️\n5. `real_time_orders` → converts cents to dollars ✅\n6. `historical_orders` → **amounts still in cents** ❌\n\n## Solution\n\n- **models/historical_orders.sql**: Apply `cents_to_dollars()` macro to all monetary fields to match real_time_orders unit normalization\n- **models/real_time_orders.sql**: Add documentation comment clarifying amounts are in dollars\n\n## Impact\nThis fix will:\n- ✅ Resolve the ongoing ROAS anomaly incidents\n- ✅ Ensure consistent dollar units across all order data\n- ✅ Prevent future unit mismatch issues in downstream models\n\n## Testing\nAfter merge, monitor:\n- `cpa_and_roas` ROAS values should return to expected ranges\n- No new anomaly incidents should be triggered\n- Historical and real-time order amounts should be in same units<br><br>Created by: `maayan+172@elementary-data.com`