### PR TITLE
Maayan via Elementary: Fix unit normalization in historical_orders to convert cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,4 +1,4 @@
-{{
+{% raw %}{{
   config(materialized='view')
 }}
 
@@ -37,9 +37,17 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+) {% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+{% raw %}-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+) {% endraw %}


### PR DESCRIPTION
## Problem

The ROAS anomaly detection test has been failing due to a unit normalization mismatch between `historical_orders` and `real_time_orders` models.

**Root Cause**: 
- `real_time_orders` correctly converts amounts from cents to dollars using the `cents_to_dollars` macro
- `historical_orders` was storing amounts in cents without conversion
- When unioned in the `orders` model, this created a 100x magnitude difference causing ROAS calculations to spike

## Solution

- Convert all monetary amounts in `historical_orders` from cents to dollars using the `cents_to_dollars` macro
- Add explanatory comment in `real_time_orders` for clarity
- Ensure both models now produce consistent dollar-denominated amounts

## Impact

This fix will:
- ✅ Resolve the ongoing HIGH severity ROAS anomaly incident
- ✅ Ensure accurate marketing attribution and ROI calculations
- ✅ Prevent future unit normalization issues in the orders pipeline

## Testing

The fix should be validated by:
1. Running the updated models
2. Verifying ROAS values return to expected ranges
3. Confirming the anomaly detection test passes<br><br>Created by: `maayan+172@elementary-data.com`