### PR TITLE
Noya Offer via Elementary: Add 'test' tag to order_items model

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -249,7 +249,7 @@ models:
     meta:
       owner: "@sales-team"
     config:
-      tags: ["sales"]
+      tags: ["sales", "test"]
     columns:
       - name: order_id
         description: "Unique identifier for an order"


### PR DESCRIPTION
This PR adds the 'test' tag to the order_items model configuration while preserving all existing settings.

## Changes Made
- Updated `models/schema.yml` to add "test" tag to order_items model
- Tags configuration changed from `["sales"]` to `["sales", "test"]`
- All other configuration remains unchanged (owner, description, columns, etc.)

## Impact
- Improves asset categorization and discoverability
- Enables filtering and grouping by the "test" tag
- Maintains backward compatibility with existing "sales" tag usage<br><br>Created by: `noya@elementary-data.com`