### PR TITLE
Maayan via Elementary: Add orders status null validation test

### DIFF
--- a/jaffle_shop_online/tests/orders_status_not_null.sql
+++ b/jaffle_shop_online/tests/orders_status_not_null.sql
@@ -1,0 +1,3 @@
+-- Test to identify orders with null status values
+-- This test will fail if any orders have null status
+select * from elementary_tests.jaffle_shop.orders where status is null


### PR DESCRIPTION
## Summary
This PR adds a singular test to identify orders with null status values.

## Changes
- Created `tests/orders_status_not_null.sql` - a singular test that will fail if any orders have null status values
- The test uses the exact SQL query as requested: `select * from elementary_tests.jaffle_shop.orders where status is null`

## Test Details
- **Type**: Singular test
- **Purpose**: Validates that no orders have null status values
- **Severity**: Will fail the dbt run if null status values are found

---
*This PR was opened by the Elementary AI agent*<br><br>Created by: `maayan+172@elementary-data.com`