### PR TITLE
Maayan via Elementary: Add custom SQL test for orders status null validation

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -73,6 +73,12 @@ models:
           config:
             owner: ["@data-ops"]
             tags: ["stability"]
+      - elementary.sql_test:
+          name: orders_custom_not_null
+          sql: "select * from elementary_tests.jaffle_shop.orders where status is null"
+          config:
+            severity: error
+            tags: ["business-rule"]
     columns:
       - name: order_id
         description: This is a unique identifier for an order


### PR DESCRIPTION
## Summary\nThis PR adds a custom SQL test named `orders_custom_not_null` to validate that no orders have null status values.\n\n## Changes\n- Added Elementary `sql_test` to the orders model in `models/schema.yml`\n- Test name: `orders_custom_not_null`\n- SQL: `select * from elementary_tests.jaffle_shop.orders where status is null`\n- Configuration: Error severity with `business-rule` tag\n\n## Test Details\n- **Type**: Elementary custom SQL test\n- **Purpose**: Validates that no orders have null status values\n- **Severity**: Error (will fail dbt run if null status values found)\n- **Tags**: `business-rule` (as requested)\n\n---\n*This PR was opened by the Elementary AI agent*<br><br>Created by: `maayan+172@elementary-data.com`