### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit conversion causing ROAS anomaly failures

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted from cents to dollars
 {{
   config(materialized='view')
 }}
@@ -29,10 +30,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- Convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The `column_anomalies` test on `return_on_advertising_spend` was failing due to a 100x unit mismatch between historical and real-time order data:

- **historical_orders**: monetary amounts kept in cents (raw values)
- **real_time_orders**: monetary amounts properly converted to dollars

This caused dramatic spikes in ROAS calculations when historical data was processed, triggering 25+ consecutive anomaly detection failures.

## Root Cause Analysis
```
cpa_and_roas (ROAS calculation) 
  ↳ attribution_touches (linear_revenue)
    ↳ customer_conversions (revenue) 
      ↳ orders (amount) ← UNION of historical + realtime
        ↳ historical_orders: amount in CENTS 
        ↳ real_time_orders: amount in DOLLARS (converted)
```

## Solution
- Convert all monetary fields in `historical_orders.sql` from cents to dollars using the existing `cents_to_dollars` macro
- Add explanatory comments to both models for clarity
- Maintain consistency with the normalization logic already present in `real_time_orders.sql`

## Impact
- Fixes the ongoing High severity incident with 25+ consecutive failures
- Ensures accurate ROAS calculations for finance reporting
- Prevents future unit-related data quality issues

## Testing
After deployment, the `column_anomalies` test should return to passing status as ROAS values will be consistently calculated from dollar amounts.<br><br>Created by: `joost@elementary-data.com`