### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization mismatch in orders models

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,4 +1,4 @@
-{{
+{% raw %}{{
   config(materialized='view')
 }}
 
@@ -37,9 +37,17 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+) {% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+{% raw %}-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+) {% endraw %}


### PR DESCRIPTION
## Problem
The column anomaly test on `return_on_advertising_spend` is failing due to a unit normalization mismatch between historical and real-time order data:

- `real_time_orders` converts monetary values from cents to dollars using the `cents_to_dollars` macro
- `historical_orders` keeps monetary values in cents (raw `total_amount`)

This creates a 100× scale difference that propagates through the entire revenue calculation pipeline: `historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing the ROAS anomaly detection to fail.

## Solution
- **`historical_orders.sql`**: Apply `cents_to_dollars` macro to all monetary fields to match the normalization in `real_time_orders`
- **`real_time_orders.sql`**: Add comment clarifying that all monetary amounts are in dollars

## Root Cause Analysis Trail
1. `cpa_and_roas.return_on_advertising_spend` = `100.0 * revenue / spend` ✅ correct formula
2. `attribution_touches.linear_revenue` = `revenue * weight` ✅ passes through correctly  
3. `customer_conversions.revenue` = `orders.amount` ✅ uses orders amount
4. `orders.amount` = `UNION` of `historical_orders` + `real_time_orders` 🚨 **unit mismatch here**
5. `real_time_orders.amount` = `cents_to_dollars(amount_cents)` ✅ normalized to dollars
6. `historical_orders.amount` = `total_amount` 🚨 **still in cents**

## Testing
After this fix, both models will output monetary values in the same unit (dollars), resolving the ROAS calculation anomaly.<br><br>Created by: `joost@elementary-data.com`