### PR TITLE
Maayan via Elementary: Add marketing-team as subscriber to cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,7 @@ models:
       by source, and per day"
     meta:
       owner: "@finance-team"
+      subscribers: "@marketing-team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
This PR adds the marketing team as a subscriber to the `cpa_and_roas` model to ensure they receive notifications when data quality incidents are resolved.

## Changes
- Added `subscribers: "@marketing-team"` to the meta section of the cpa_and_roas model in `models/marketing/schema.yml`

## Context
The cpa_and_roas model currently has active data quality incidents, including a high-severity column anomaly on the RETURN_ON_ADVERTISING_SPEND column. Adding the marketing team as subscribers will ensure they're notified when these issues are resolved, keeping them informed about the health of this critical marketing metric.

## Validation
- ✅ Only added the subscribers field, no existing configuration was modified
- ✅ Follows dbt meta configuration best practices
- ✅ Maintains existing owner (@finance-team) and other metadata<br><br>Created by: `maayan+172@elementary-data.com`