### PR TITLE
Maayan via Elementary: Fix currency unit mismatch in orders models

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are converted from cents to dollars
 {{
   config(materialized='view')
 }}
@@ -29,10 +30,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\n\nThe column anomalies test on `return_on_advertising_spend` in the `cpa_and_roas` model was failing due to a currency unit mismatch between historical and real-time order data.\n\n**Root Cause**: The `orders` model unions two sources with inconsistent currency units:\n- `real_time_orders`: Properly converts cents to dollars using `cents_to_dollars` macro\n- `historical_orders`: Keeps monetary fields in raw cents (no conversion)\n\nThis created a 100× difference that propagated upstream, causing ROAS calculations to be artificially inflated when historical data was included.\n\n## Solution\n\n1. **Fixed historical_orders.sql**: Apply `cents_to_dollars` macro to all monetary fields in the `final` CTE\n2. **Added clarity comments**: Document currency normalization in both models\n\n## Impact\n\n✅ **Fixes**: Column anomaly detection on `return_on_advertising_spend`  \n✅ **Ensures**: Consistent dollar units across all order data  \n✅ **Prevents**: ROAS calculation errors affecting marketing attribution analysis  \n\nThis addresses the HIGH severity incident affecting the critical `cpa_and_roas` finance model."<br><br>Created by: `maayan+172@elementary-data.com`