### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch: Convert historical orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,23 +1,24 @@
+-- All monetary amounts in this model are converted from cents to dollars
 {{
   config(materialized='view')
 }}
 
-{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
+{% raw %}{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}{% endraw %}
 
 with orders as (
-    select * from {{ ref('stg_orders') }}
+    select * from {% raw %}{{ ref('stg_orders') }}{% endraw %}
 ),
 
 payments as (
-    select * from {{ ref('stg_payments') }}
+    select * from {% raw %}{{ ref('stg_payments') }}{% endraw %}
 ),
 
 order_payments as (
     select
         order_id,
-        {% for payment_method in payment_methods -%}
+        {% raw %}{% for payment_method in payment_methods -%}
         sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,
-        {% endfor -%}
+        {% endfor -%}{% endraw %}
         sum(amount) as total_amount
     from payments
     group by order_id
@@ -29,15 +30,24 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
-        {% for payment_method in payment_methods -%}
+        {% raw %}{% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
-        {% endfor -%}
-        op.total_amount    as amount
+        {% endfor -%}{% endraw %}
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% raw %}{{ cents_to_dollars('bank_transfer_amount') }}{% endraw %} as bank_transfer_amount,
+    {% raw %}{{ cents_to_dollars('coupon_amount') }}{% endraw %} as coupon_amount,
+    {% raw %}{{ cents_to_dollars('credit_card_amount') }}{% endraw %} as credit_card_amount,
+    {% raw %}{{ cents_to_dollars('gift_card_amount') }}{% endraw %} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,23 +1,24 @@
+-- All monetary amounts in this model are converted from cents to dollars
 {{
   config(materialized='view')
 }}
 
-{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
+{% raw %}{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}{% endraw %}
 
 with orders as (
-    select * from {{ ref('stg_orders') }}
+    select * from {% raw %}{{ ref('stg_orders') }}{% endraw %}
 ),
 
 payments as (
-    select * from {{ ref('stg_payments') }}
+    select * from {% raw %}{{ ref('stg_payments') }}{% endraw %}
 ),
 
 order_payments as (
     select
         order_id,
-        {% for payment_method in payment_methods -%}
+        {% raw %}{% for payment_method in payment_methods -%}
         sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,
-        {% endfor -%}
+        {% endfor -%}{% endraw %}
         sum(amount) as total_amount
     from payments
     group by order_id
@@ -29,9 +30,9 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
-        {% for payment_method in payment_methods -%}
+        {% raw %}{% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
-        {% endfor -%}
+        {% endfor -%}{% endraw %}
         op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
@@ -42,11 +43,11 @@ select
     customer_id,
     order_date,
     status,
-    {{ cents_to_dollars('amount_cents') }} as amount,
-    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
-    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
-    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
-    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
+    {% raw %}{{ cents_to_dollars('amount_cents') }}{% endraw %} as amount,
+    {% raw %}{{ cents_to_dollars('bank_transfer_amount') }}{% endraw %} as bank_transfer_amount,
+    {% raw %}{{ cents_to_dollars('coupon_amount') }}{% endraw %} as coupon_amount,
+    {% raw %}{{ cents_to_dollars('credit_card_amount') }}{% endraw %} as credit_card_amount,
+    {% raw %}{{ cents_to_dollars('gift_card_amount') }}{% endraw %} as gift_card_amount
 from final
 where date(order_date) = (
     select date(max(order_date)) from final


### PR DESCRIPTION
## Problem\nThe `return_on_advertising_spend` anomaly detection test has been failing due to a unit mismatch between historical and real-time order data:\n\n- **Real-time orders**: Amounts are converted from cents to dollars using `cents_to_dollars` macro\n- **Historical orders**: Amounts remain in raw cents format\n- **Result**: Historical orders appear 100x larger, causing inflated ROAS calculations\n\n## Root Cause Analysis\nThe issue was traced through the data lineage:\n1. `cpa_and_roas` calculates ROAS as `revenue / ad_spend`\n2. Revenue flows from `attribution_touches` → `customer_conversions` → `orders`\n3. `orders` model unions `historical_orders` and `real_time_orders`\n4. Unit inconsistency: cents vs dollars\n\n## Solution\n- **historical_orders.sql**: Apply `cents_to_dollars` macro to all monetary fields to match real-time orders\n- **real_time_orders.sql**: Add clarifying comment about unit normalization\n\n## Impact\n- Fixes ROAS anomaly test failures\n- Ensures consistent monetary units across the entire data pipeline\n- Prevents misleading financial metrics for marketing decisions\n\n## Testing\nAfter this fix, the ROAS calculations will be accurate and the anomaly detection test should pass.<br><br>Created by: `joost@elementary-data.com`