### PR TITLE
Maayan via Elementary: Fix unit mismatch: Convert historical orders from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,7 +1,6 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (


### PR DESCRIPTION
## Problem
The `cpa_and_roas` model is experiencing column anomaly incidents because of a unit mismatch in the underlying `orders` data:

- **historical_orders**: Amount fields stored in cents (raw values)
- **real_time_orders**: Amount fields already converted to dollars via `cents_to_dollars` macro

When these are unioned in the `orders` model, historical orders appear 100x larger than real-time orders, causing massive spikes in ROAS calculations.

## Root Cause Analysis Trail
1. **cpa_and_roas** → ROAS calculation: `100.0 * attribution_revenue / total_spend` ✅
2. **attribution_touches** → Uses `linear_revenue` from revenue calculation ✅  
3. **customer_conversions** → Uses `orders.amount` directly as revenue ⚠️
4. **orders** → Simple `UNION ALL` of historical + real-time 🚨
5. **historical_orders** → `op.total_amount as amount` (cents) 💥
6. **real_time_orders** → `cents_to_dollars('amount_cents') as amount` (dollars) ✅

## Solution
- Apply `cents_to_dollars` macro to all monetary fields in `historical_orders.sql`
- Add documentation comment to `real_time_orders.sql` for clarity
- Ensures both data sources use consistent dollar units

## Impact
- **Fixes**: ROAS anomaly incidents on the critical `cpa_and_roas` model
- **Improves**: Data integrity across the entire orders pipeline
- **Benefits**: Finance team gets accurate marketing attribution metrics

## Testing
After deployment, the column anomaly test should pass as revenue calculations will be consistent across historical and real-time data periods.<br><br>Created by: `maayan+172@elementary-data.com`