### PR TITLE
Mika Kerman via Elementary: Rename marketing team owner from @marketing-team to @mrk-team

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: ads_spend
     description: "This table contains the daily ad spend, by source, medium and campaign"
     meta:
-      owner: "@marketing-team"
+      owner: "@mrk-team"
     config:
       tags: ["marketing", "finance", "finance-data-product"]
       elementary:
@@ -36,7 +36,7 @@ models:
     description: "This is a table that contains all the touch points, by session,
       with the utm_source, utm_medium and utm_campaign"
     meta:
-      owner: "@marketing-team"
+      owner: "@mrk-team"
     config:
       tags: ["marketing", "pii", "finance-data-product"]
       elementary:
@@ -182,7 +182,7 @@ models:
     description: "This table contains information on the ad spend, by source, medium
       and campaign"
     meta:
-      owner: "@marketing-team"
+      owner: "@mrk-team"
     config:
       tags: ["marketing", "finance"]
       elementary:
@@ -217,7 +217,7 @@ models:
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
     meta:
-      owner: "@marketing-team"
+      owner: "@mrk-team"
     config:
       tags: ["marketing"]
       elementary:
@@ -256,7 +256,7 @@ models:
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
     meta:
-      owner: "@marketing-team"
+      owner: "@mrk-team"
     config:
       tags: ["marketing", "finance", "pii"]
       elementary:
@@ -278,7 +278,7 @@ models:
     description: "This table contains information on the sessions of all the customers
       and the utm_source, utm_medium and utm_campaign of the session"
     meta:
-      owner: "@marketing-team"
+      owner: "@mrk-team"
     config:
       tags: ["marketing", "pii"]
       elementary:


### PR DESCRIPTION
This PR renames the marketing team owner from @marketing-team to @mrk-team across all affected models in the marketing directory.

## Changes Made
- Updated owner from `@marketing-team` to `@mrk-team` for 6 marketing models
- No other metadata was modified

## Affected Models
- **ads_spend** - Daily ad spend by campaign
- **attribution_touches** - Touch point attribution data  
- **marketing_ads** - Marketing ad spend information
- **agg_sessions** - Aggregated session information
- **customer_conversions** - Customer conversion tracking
- **sessions** - Session data with UTM parameters

All changes are contained within `models/marketing/schema.yml`.<br><br>Created by: `mika@elementary-data.com`