### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix ROAS anomaly: normalize historical orders amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -29,10 +29,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- Convert every monetary field from cents to dollars
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The **column_anomalies** test on `return_on_advertising_spend` in the `cpa_and_roas` model has been failing with 37 consecutive failures due to a unit normalization mismatch.

## Root Cause

Through upstream investigation, I discovered that:

- **historical_orders** stores amounts in **cents** (no conversion)
- **real_time_orders** properly converts amounts from **cents to dollars** (÷ 100)
- When these are UNIONed in the `orders` model, historical data is 100× larger
- This mismatch propagates through the data pipeline to ROAS calculations

## Solution

This PR fixes the unit normalization by:

1. **historical_orders.sql**: Converting all monetary fields from cents to dollars using the `cents_to_dollars` macro
2. **real_time_orders.sql**: Adding documentation that all amounts are in dollars

## Impact

- Resolves the HIGH severity incident affecting the critical `cpa_and_roas` model
- Ensures consistent unit handling across historical and real-time data sources
- Prevents future ROAS calculation anomalies

## Testing

After deployment, the ROAS values should normalize and the anomaly detection should stop triggering false positives.<br><br>Created by: `joost@elementary-data.com`