### PR TITLE
Maayan via Elementary: Fix: Normalize historical orders unit mismatch (cents → dollars)

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,4 +1,5 @@
-{{
+{% raw %}-- All monetary amounts in this model are converted from cents to dollars
+{{ 
   config(materialized='view')
 }}
 
@@ -30,9 +31,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
@@ -42,4 +43,4 @@ from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+) {% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+{% raw %}-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+) {% endraw %}


### PR DESCRIPTION
## 🐛 Bug Fix: Resolve Unit Mismatch in Orders Models

### Problem
The `column_anomalies` test on `RETURN_ON_ADVERTISING_SPEND` was failing due to a **100× unit mismatch** between historical and real-time order data:

- **real_time_orders**: Amounts properly converted from cents to dollars
- **historical_orders**: Amounts left in cents (no conversion)

This caused massive spikes in ROAS calculations when historical data was included in attribution revenue.

### Root Cause Analysis
Through SQL code walk investigation:
1. `cpa_and_roas` calculates ROAS using `attribution_revenue`
2. `attribution_touches` passes through `revenue` from conversions
3. `customer_conversions` uses `amount` from orders
4. `orders` performs `UNION ALL` of `historical_orders` + `real_time_orders`
5. **Unit mismatch**: Historical amounts in cents, real-time amounts in dollars

### Solution
- Convert all monetary amounts in `historical_orders.sql` from cents to dollars using the existing `cents_to_dollars` macro
- Add clarifying comments to both models about unit expectations
- Ensures consistent dollar-denominated amounts across both data sources

### Impact
- ✅ Resolves ROAS anomaly detection failures
- ✅ Ensures accurate marketing attribution calculations
- ✅ Maintains data consistency across historical and real-time pipelines

### Testing
This change will normalize the units and should resolve the anomaly test failures on the next dbt run.<br><br>Created by: `maayan+172@elementary-data.com`