### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch: normalize historical_orders amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    -- Convert every monetary field from cents to dollars
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount  -- Amount is now in dollars
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{ config(materialized='view') }}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Problem
The `historical_orders` and `real_time_orders` models had inconsistent unit normalization for monetary amounts:

- **real_time_orders**: Converted amounts from cents to dollars using `cents_to_dollars()` macro
- **historical_orders**: Left amounts in cents (no conversion)

This created a **100x unit mismatch** when the two models were unioned in the `orders` model, causing the RETURN_ON_ADVERTISING_SPEND anomaly detection to trigger repeatedly (41+ failures).

## Solution
- ✅ **historical_orders.sql**: Added `cents_to_dollars()` conversion for all monetary fields
- ✅ **real_time_orders.sql**: Added documentation comment explaining dollar normalization  
- ✅ **Consistent units**: Both models now output amounts in dollars

## Impact
- **Resolves**: Elementary incident `#2924da99` (HIGH severity)  
- **Fixes**: ROAS calculations that were inflated 100x due to unit mismatch
- **Prevents**: Marketing budget decisions based on incorrect metrics

## Testing
After this change, both order data sources will have consistent dollar-denominated amounts, eliminating the anomaly detection false positives.<br><br>Created by: `joost@elementary-data.com`