### PR TITLE
Noya Offer via Elementary: Add PII tags to raw customer seed files

### DIFF
--- a/jaffle_shop_online/models/seeds.yml
+++ b/jaffle_shop_online/models/seeds.yml
@@ -1,6 +1,28 @@
 version: 2
 
 seeds:
+  - name: raw_customers_training
+    description: "Raw customer training data containing personally identifiable information"
+    tags: ["pii"]
+    columns:
+      - name: id
+        description: "Unique identifier for a customer"
+      - name: first_name
+        description: "Customer's first name. PII."
+      - name: last_name
+        description: "Customer's last name. PII."
+
+  - name: raw_customers_validation
+    description: "Raw customer validation data containing personally identifiable information"
+    tags: ["pii"]
+    columns:
+      - name: id
+        description: "Unique identifier for a customer"
+      - name: first_name
+        description: "Customer's first name. PII."
+      - name: last_name
+        description: "Customer's last name. PII."
+
   - name: stg_app_sessions
     description: "App session data for marketing attribution analysis"
     config:


### PR DESCRIPTION
This PR adds the `pii` tag to raw customer seed files that contain personally identifiable information (first_name, last_name) but were missing proper PII classification.

**Files updated:**
- `raw_customers_training.csv` - Contains first_name, last_name  
- `raw_customers_validation.csv` - Contains first_name, last_name

**Changes made:**
- Added seed configurations in `models/seeds.yml`
- Applied `pii` tag to both seed files
- Added descriptions identifying these as PII-containing assets
- Added column-level descriptions marking PII fields

This ensures consistent PII governance across the entire data pipeline and helps with compliance and data protection efforts.<br><br>Created by: `noya@elementary-data.com`