### PR TITLE
Maayan via Elementary: Add upstream data quality tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -34,13 +34,17 @@ models:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+    data_tests:
+      - elementary.volume_anomalies:
+          timestamp_column: order_date
+          where_expression: order_date is not null
+      - elementary.freshness_anomalies:
+          timestamp_column: order_date
   - name: stg_payments
     meta:
       owner: "@finance-team"
@@ -59,6 +63,12 @@ models:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
 
+    data_tests:
+      - elementary.volume_anomalies:
+          timestamp_column: order_id
+          where_expression: order_id is not null
+      - elementary.freshness_anomalies:
+          timestamp_column: order_id
   - name: stg_signups
     meta:
       owner: "@customer-team"


### PR DESCRIPTION
This PR adds critical upstream data quality tests for the `cpa_and_roas` model to ensure reliable marketing analytics:

**Tests Added:**

### stg_orders model:
- **Volume anomaly detection**: Monitors for unusual changes in order record volumes
- **Freshness anomaly detection**: Ensures staging data is updated regularly

### stg_payments model: 
- **Volume anomaly detection**: Detects unexpected changes in payment record volumes
- **Freshness anomaly detection**: Monitors payment data freshness

**Business Impact:**
These tests protect the integrity of the `cpa_and_roas` model by monitoring key upstream staging tables. Early detection of data quality issues in these foundational models prevents inaccurate cost per acquisition and return on advertising spend calculations, ensuring reliable marketing ROI metrics for the finance and marketing teams.<br><br>Created by: `maayan+172@elementary-data.com`