### PR TITLE
Maayan via Elementary: Fix unit normalization: convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem
The ROAS anomaly detection is failing because of a unit mismatch between `historical_orders` and `real_time_orders` models:

- **`historical_orders`**: Amounts stored in **cents** (no conversion)
- **`real_time_orders`**: Amounts converted to **dollars** using `cents_to_dollars()` macro

When these models are unioned in the `orders` model, historical data inflates ROAS calculations by 100x, triggering anomaly alerts.

## Root Cause Analysis
```
cpa_and_roas (ROAS = revenue / spend * 100)
├── attribution_touches (linear_revenue)
├── customer_conversions (revenue = orders.amount) 
├── orders (UNION ALL historical_orders + real_time_orders)
├── real_time_orders (✅ dollars: cents_to_dollars conversion)
└── historical_orders (❌ cents: no conversion) ← **ROOT CAUSE**
```

## Solution
1. **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary fields to match `real_time_orders` normalization
2. **`real_time_orders.sql`**: Add clarifying comment about dollar amounts

## Changes Made
- Convert `total_amount` → `amount_cents` → `cents_to_dollars('amount_cents')` as `amount`
- Apply same conversion to all payment method amounts
- Add explicit column selection to ensure consistency
- Add documentation comment in `real_time_orders.sql`

## Business Impact
- Fixes inflated ROAS calculations for historical data
- Ensures consistent unit normalization across the pipeline  
- Resolves **High** severity incident on critical marketing metrics

## Testing
After deployment, verify:
- Historical and real-time order amounts are in same units (dollars)  
- ROAS anomaly detection stabilizes
- Marketing attribution metrics show realistic values<br><br>Created by: `maayan+172@elementary-data.com`