### PR TITLE
Mika via Elementary: Fix: Normalize historical_orders monetary fields to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,4 +1,4 @@
-{{
+{% raw %}{{
   config(materialized='view')
 }}
 
@@ -32,14 +32,23 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    -- Convert all monetary fields from cents to dollars
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+) {% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,5 @@
+{% raw %}-- All monetary amounts in this model are in dollars
+
 {{
   config(materialized='view')
 }}
@@ -50,4 +52,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+) {% endraw %}


### PR DESCRIPTION
## Problem

The ROAS anomaly detection test on `cpa_and_roas` has been failing with 47 consecutive failures since October 22, 2025. 

**Root Cause:** Unit mismatch in the `orders` model which unions `historical_orders` and `real_time_orders`:
- `historical_orders.amount` was in **cents** (no conversion applied)
- `real_time_orders.amount` was in **dollars** (converted via `cents_to_dollars` macro)

This 100× mismatch propagated through:
- `customer_conversions.revenue` → `attribution_touches.linear_revenue` → `cpa_and_roas.return_on_advertising_spend`

## Solution

✅ **historical_orders.sql**: Convert all monetary fields from cents to dollars using the `cents_to_dollars` macro
✅ **real_time_orders.sql**: Add clarifying comment that amounts are in dollars

## Changes

- Renamed `amount` → `amount_cents` in the `final` CTE of `historical_orders`
- Applied `cents_to_dollars()` macro to all payment method amounts and the total amount
- Added explanatory comment in `real_time_orders` for future maintainability

## Impact

This fix ensures both branches of the `orders` union use consistent dollar-denominated values, resolving the ROAS calculation anomalies.<br><br>Created by: `mika+demo@elementary-data.com`