### PR TITLE
Mika via Elementary: Add @marketing_team as subscriber to cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -125,6 +125,8 @@ models:
       by source, and per day"
     meta:
       owner: "@finance-team"
+      subscribers:
+        - "@marketing_team"
     config:
       tags:
         - "finance"


### PR DESCRIPTION
## Summary
This PR adds @marketing_team as a subscriber to the `cpa_and_roas` model.

## Changes
- Updated `models/marketing/schema.yml` to include @marketing_team in the subscribers list for the cpa_and_roas model

## Impact
- The marketing team will now receive notifications about data quality issues and updates related to the cpa_and_roas asset
- This ensures the team stays informed about the ROAS metric, especially regarding the current HIGH severity anomaly on the return_on_advertising_spend column<br><br>Created by: `mika+demo@elementary-data.com`