### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix: Normalize historical_orders monetary amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## 🐛 Problem

The `historical_orders` model was outputting monetary amounts in **cents**, while `real_time_orders` was converting to **dollars**. Since both models are unioned in the `orders` model, this created a **100× scale mismatch** that propagated through:
- `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

This caused the `return_on_advertising_spend` column to show inflated values, triggering **47 consecutive anomaly test failures** since October 22, 2025.

---

## ✅ Solution

1. **historical_orders.sql**: Apply `cents_to_dollars` macro to all monetary fields (matching the normalization in `real_time_orders`)
2. **real_time_orders.sql**: Add clarifying comment documenting that amounts are in dollars

---

## 🎯 Impact

- Fixes ROAS anomaly incident
- Ensures consistent dollar-denominated values across both historical and real-time data branches
- Aligns with existing normalization pattern in `real_time_orders`

---

## ✔️ Testing

After merging, verify:
- Run `dbt build` to ensure models compile and execute successfully
- Check that `orders.amount` values are consistent across both branches
- Monitor the `column_anomalies` test on `cpa_and_roas.return_on_advertising_spend` for resolution<br><br>Created by: `joost@elementary-data.com`