### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch: normalize historical_orders amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -30,9 +28,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
@@ -42,4 +40,4 @@ from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are normalized to dollars
 {{
   config(materialized='view')
 }}
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+)


### PR DESCRIPTION
## 🔴 Problem
The `orders` model unions `historical_orders` and `real_time_orders`, but they use inconsistent monetary units:
- **real_time_orders**: Converts cents to dollars using `cents_to_dollars()` macro ✅
- **historical_orders**: Keeps raw cent values without conversion ❌

This **100× magnitude difference** propagates upstream to `cpa_and_roas`, causing the **ROAS anomaly detection test** to fail with 48 consecutive failures.

## ✅ Solution
1. Apply `cents_to_dollars()` macro to all monetary fields in `historical_orders.sql`
2. Add clarifying comment to `real_time_orders.sql` documenting unit normalization

## 📊 Impact
**Fixes incident**: `column_anomalies` test on `RETURN_ON_ADVERTISING_SPEND` in **cpa_and_roas** model

**Affected models in lineage**:
- `historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

## 🧪 Testing Recommendation
After merge, consider adding a data test to prevent future unit mismatches between the two order sources.<br><br>Created by: `joost@elementary-data.com`