### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix: Normalize monetary amounts to dollars in historical_orders

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🐛 Problem

The `column_anomalies` test on `cpa_and_roas.return_on_advertising_spend` has been failing with 48 consecutive failures since October 2025. 

### Root Cause Analysis

Through lineage investigation, I traced the issue to a **unit normalization mismatch** in the `orders` model:

| Model | Amount Field | Unit |
|-------|--------------|------|
| **historical_orders** | `amount` | ❌ **Cents** (no conversion) |
| **real_time_orders** | `amount` | ✅ **Dollars** (converted via `cents_to_dollars` macro) |

Since `orders` is a UNION ALL of these two models, this creates a **100× discrepancy** that propagates through:
1. `orders.amount` 
2. → `customer_conversions.revenue`
3. → `attribution_touches.linear_revenue`
4. → `cpa_and_roas.return_on_advertising_spend`

---

## ✅ Solution

This PR standardizes both models to output monetary amounts in **dollars**:

### Changes to `historical_orders.sql`
- Rename intermediate field to `amount_cents` for clarity
- Apply `cents_to_dollars` macro to all monetary fields (matching `real_time_orders`)
- Convert: `amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`

### Changes to `real_time_orders.sql`
- Add documentation comment: "All monetary amounts in this model are in dollars"

---

## 🧪 Expected Impact

- ✅ Fixes the ROAS anomaly detection test failures
- ✅ Ensures consistent units across the entire marketing attribution pipeline
- ✅ Prevents future incidents from unit mismatches

---

## 📊 Affected Models

This fix impacts the critical **@finance-team** data product:
- `orders` ← direct fix
- `customer_conversions` ← uses orders.amount
- `attribution_touches` ← uses conversions.revenue  
- `cpa_and_roas` ← uses attribution_touches.linear_revenue (incident source)<br><br>Created by: `joost@elementary-data.com`