### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit mismatch in historical_orders amount normalization

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 


### PR DESCRIPTION
## Problem
The `historical_orders` model stores monetary amounts in **cents** while `real_time_orders` converts them to **dollars**. When these models are unioned in the `orders` model, this creates a 100× mismatch that propagates through:
- `customer_conversions` → `attribution_touches` → `cpa_and_roas`

This causes the ROAS anomaly detection test to fail with large deviations.

## Root Cause
**Incident:** #2924da99-a790-4dcb-b92a-5f9571d1fdce  
**Failing Test:** `column_anomalies` on `RETURN_ON_ADVERTISING_SPEND` column in `cpa_and_roas`

The investigation traced the issue through the SQL code:
- `cpa_and_roas` calculates ROAS correctly as `revenue / spend`
- Revenue flows from `attribution_touches.linear_revenue` 
- Which comes from `customer_conversions.revenue`
- Which uses `orders.amount`
- `orders` unions `historical_orders` and `real_time_orders`
- **`real_time_orders`** converts cents to dollars ✅
- **`historical_orders`** does NOT convert cents to dollars ❌

## Solution
This PR aligns `historical_orders` with `real_time_orders` by:
1. Renaming `total_amount as amount` to `total_amount as amount_cents` in the `final` CTE
2. Adding a final SELECT that converts all monetary fields using the `cents_to_dollars()` macro
3. Adding a clarifying comment to `real_time_orders.sql` documenting that amounts are in dollars

## Impact
- ✅ Fixes the 100× unit mismatch between historical and real-time orders
- ✅ ROAS calculations will now be accurate across the full dataset
- ✅ Resolves the failing anomaly detection test on `cpa_and_roas`

## Testing
After this PR is merged and the models are rebuilt:
- The `orders` model will have consistent dollar-denominated amounts
- The ROAS metric should stabilize
- The anomaly detection test should pass<br><br>Created by: `joost@elementary-data.com`