### PR TITLE
Maayan via Elementary: Fix: Normalize historical_orders monetary amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,7 +1,8 @@
-{{
+{% raw %}{{
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -30,9 +31,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
@@ -42,4 +43,4 @@ from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+) {% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,7 +1,8 @@
-{{
+{% raw %}{{
   config(materialized='view')
 }}
 
+-- All monetary amounts in this model are in dollars
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
 with orders as (
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+) {% endraw %}


### PR DESCRIPTION
## Problem
The `column_anomalies` test on `return_on_advertising_spend` in the `cpa_and_roas` model has been failing with 49 consecutive failures since the incident opened.

## Root Cause
**Unit normalization mismatch** between two data sources:
- `historical_orders` → amounts stored in **cents** (no conversion)
- `real_time_orders` → amounts converted to **dollars** via `cents_to_dollars` macro

Since `orders` UNIONs these two models, the 100× discrepancy propagates through:
1. `orders.amount` (mixed units)
2. `customer_conversions.revenue`
3. `attribution_touches.linear_revenue`
4. `cpa_and_roas.return_on_advertising_spend`

This caused ROAS calculations to be wildly incorrect, triggering anomaly detection.

## Solution
Apply the `cents_to_dollars` macro to all monetary fields in `historical_orders.sql`:
- `credit_card_amount`
- `coupon_amount`
- `bank_transfer_amount`
- `gift_card_amount`
- `amount` (total)

Also added documentation comments to both models clarifying that all monetary amounts are in dollars.

## Impact
- **Criticality:** HIGH (finance-data-product, owned by @finance-team)
- **Affected Models:** `cpa_and_roas`, `attribution_touches`, `customer_conversions`, `orders`
- **Business Impact:** Fixes reliability of ROAS and CPA metrics used for financial reporting

## Testing
After merge, the anomaly test should pass on the next dbt run when historical and real-time data use consistent units.

---
**Incident ID:** `2924da99-a790-4dcb-b92a-5f9571d1fdce`<br><br>Created by: `maayan+172@elementary-data.com`