### PR TITLE
Maayan via Elementary: Fix: Normalize historical_orders monetary amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,4 +1,4 @@
-{{
+{% raw %}{{
   config(materialized='view')
 }}
 
@@ -32,14 +32,23 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+) {% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+{% raw %}-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+) {% endraw %}


### PR DESCRIPTION
## Problem

The `historical_orders` model was storing monetary amounts in **cents**, while `real_time_orders` was converting amounts to **dollars**. When these two models are unioned in the `orders` model, this created a **100x scale mismatch** that propagated through the marketing attribution pipeline.

## Impact

- **50 consecutive failures** of the `column_anomalies` test on `return_on_advertising_spend` in the `cpa_and_roas` model
- **Critical business impact**: @finance-team relies on accurate ROAS metrics for marketing budget allocation
- Inflated revenue calculations making marketing channels appear 100x more effective than reality

## Root Cause Analysis

Investigation traced the issue through 5 hops of lineage:
1. `cpa_and_roas` - ROAS calculation was correct
2. `attribution_touches` - linear_revenue calculation was correct  
3. `customer_conversions` - correctly used orders.amount
4. `orders` - UNION ALL of two branches revealed the mismatch
5. **`real_time_orders`** ✅ converts cents → dollars with `cents_to_dollars()` macro
6. **`historical_orders`** ❌ keeps amounts in cents without conversion

## Solution

**models/historical_orders.sql**:
- Renamed `total_amount` → `amount_cents` for clarity
- Applied `cents_to_dollars()` macro to all monetary fields (`amount`, `bank_transfer_amount`, `coupon_amount`, `credit_card_amount`, `gift_card_amount`)
- Now matches the normalization pattern in `real_time_orders`

**models/real_time_orders.sql**:
- Added clarifying comment documenting that all monetary amounts are in dollars

## Testing

After merging and running dbt:
- The `orders` model will have consistent dollar-denominated amounts from both branches
- Revenue calculations in `customer_conversions`, `attribution_touches`, and `cpa_and_roas` will be accurate
- The `column_anomalies` test should pass once the pipeline runs with corrected data<br><br>Created by: `maayan+172@elementary-data.com`