### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix unit normalization in historical_orders (cents → dollars)

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount{{ ',' if not loop.last }}
+    {% endfor %}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🐛 Bug Fix: Unit Normalization Mismatch

### Problem
The `historical_orders` model was storing monetary amounts in **cents**, while `real_time_orders` was converting to **dollars**. This created a **100x mismatch** when the two models were unioned in the `orders` model.

### Impact
- The mismatch propagated through `customer_conversions` → `attribution_touches` → `cpa_and_roas`
- Caused the `RETURN_ON_ADVERTISING_SPEND` metric to spike dramatically
- Triggered 57 consecutive anomaly detection test failures
- Affected critical finance reporting (model is tagged as `finance-data-product` and owned by `@finance-team`)

### Root Cause Analysis
Following the data lineage upstream:
1. **cpa_and_roas**: ROAS calculation correct (`100.0 * attribution_revenue / total_spend`)
2. **attribution_touches**: Passes through `revenue * linear_weight` 
3. **customer_conversions**: Maps `orders.amount as revenue`
4. **orders**: UNION of `historical_orders` (cents) + `real_time_orders` (dollars) ❌
5. **historical_orders**: `total_amount as amount` — no conversion
6. **real_time_orders**: `cents_to_dollars(amount_cents) as amount` — converted ✅

### Solution
- Apply the `cents_to_dollars()` macro to all monetary fields in `historical_orders`
- Use Jinja loop for payment method conversions (follows DRY principle)
- Add clarifying comment to `real_time_orders` for future maintainers

### Testing
After this change:
- Both branches of the orders union will use consistent dollar units
- ROAS calculations will be accurate
- Anomaly detection tests should pass once fresh data flows through

### Files Changed
- `models/historical_orders.sql` — Added cents-to-dollars conversion
- `models/real_time_orders.sql` — Added documentation comment<br><br>Created by: `joost@elementary-data.com`