### PR TITLE
Maayan via Elementary: Fix unit mismatch in historical_orders causing ROAS anomaly

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `column_anomalies` test on `RETURN_ON_ADVERTISING_SPEND` in the `cpa_and_roas` model has been failing with **57 consecutive failures** since October 2025.

## Root Cause

Through lineage analysis, I identified a **unit normalization mismatch** between the two branches of the `orders` model:

- **real_time_orders**: Converts `amount_cents` to dollars using the `cents_to_dollars` macro ✅
- **historical_orders**: Kept `total_amount` in cents without conversion ❌

Since `orders` performs a `UNION ALL` of these two sources, this created a ~100× scale difference that propagated through:
1. `customer_conversions` (uses `orders.amount` as `revenue`)
2. `attribution_touches` (multiplies by attribution weights)
3. `cpa_and_roas` (calculates ROAS = revenue / spend)

## Solution

**historical_orders.sql**:
- Renamed `total_amount` to `amount_cents` for clarity
- Applied `cents_to_dollars` macro to all monetary fields
- Now matches the structure and units of `real_time_orders`

**real_time_orders.sql**:
- Added clarifying comment about dollar normalization

## Impact

- **Fixes**: ROAS anomaly incident (57 consecutive test failures)
- **Affected assets**: All finance-data-product downstream models
- **Business impact**: Finance team can now trust attribution metrics for budget decisions

## Testing

After merge, the `column_anomalies` test on `cpa_and_roas.return_on_advertising_spend` should pass once the pipeline runs with corrected historical data.<br><br>Created by: `maayan+172@elementary-data.com`