### PR TITLE
Joost Boonzajer Flaes via Elementary: Add Ownership to Elementary Observability Models

### DIFF
--- a/jaffle_shop_online/dbt_project.yml
+++ b/jaffle_shop_online/dbt_project.yml
@@ -32,6 +32,8 @@ clean-targets: # directories to be removed by `dbt clean`
 models:
   elementary:
     +schema: elementary
+    +meta:
+      owner: "data-engineering@acme.com"
 # on-run-end:
 #   - "{{ elementary.upload_dbt_artifacts(results) }}"
 


### PR DESCRIPTION
# Add Ownership to Elementary Observability Models

## Summary
This PR addresses ownership gaps by assigning `data-engineering@acme.com` as the owner for all Elementary framework models.

## Changes
- Updated `dbt_project.yml` to add owner metadata for all Elementary models
- Affects 24 models across alerts, artifacts, run results, and data monitoring categories

## Impacted Assets
- **Alert Models** (5): anomaly detection, dbt models/tests, source freshness, schema changes
- **Artifact Models** (8): dbt models, sources, tests, exposures, metrics, seeds, snapshots, columns
- **Run Results** (5): elementary tests, model runs, test runs, snapshot runs, test result rows
- **Data Monitoring** (4): metrics, schema columns/snapshots, threshold sensitivity
- **System Models** (2): dbt artifacts, filtered information schema

## Rationale
Elementary models are infrastructure/observability components that align with data engineering team responsibilities, consistent with existing ownership patterns in the codebase.<br><br>Created by: `joost@elementary-data.com`