### PR TITLE
Maayan via Elementary: Add unique tests to source table primary keys

### DIFF
--- a/jaffle_shop_online/models/elementary.yml
+++ b/jaffle_shop_online/models/elementary.yml
@@ -1,0 +1,43 @@
+models:
+  - name: stg_facebook_ads
+    columns:
+      - name: ad_id
+        data_tests:
+          - unique:
+              arguments:
+                column_name: ad_id
+  - name: stg_google_ads
+    columns:
+      - name: ad_id
+        data_tests:
+          - unique:
+              arguments:
+                column_name: ad_id
+  - name: stg_instagram_ads
+    columns:
+      - name: ad_id
+        data_tests:
+          - unique:
+              arguments:
+                column_name: ad_id
+  - name: elementary_exposures
+    columns:
+      - name: unique_id
+        data_tests:
+          - unique:
+              arguments:
+                column_name: unique_id
+  - name: stg_app_sessions
+    columns:
+      - name: session_id
+        data_tests:
+          - unique:
+              arguments:
+                column_name: session_id
+  - name: stg_website_sessions
+    columns:
+      - name: session_id
+        data_tests:
+          - unique:
+              arguments:
+                column_name: session_id

--- a/jaffle_shop_online/models/marketing/staging/sources.yml
+++ b/jaffle_shop_online/models/marketing/staging/sources.yml
@@ -5,11 +5,45 @@ sources:
     schema: "{{ target.schema }}"
     tables:
       - name: stg_google_ads
+        columns:
+          - name: ad_id
+            data_tests:
+              - unique:
+                  config:
+                    severity: error
+                    tags: ['business-rule']
       - name: stg_facebook_ads
+        columns:
+          - name: ad_id
+            data_tests:
+              - unique:
+                  config:
+                    severity: error
+                    tags: ['business-rule']
       - name: stg_instagram_ads
-
+        columns:
+          - name: ad_id
+            data_tests:
+              - unique:
+                  config:
+                    severity: error
+                    tags: ['business-rule']
   - name: sessions
     schema: "{{ target.schema }}"
     tables:
       - name: stg_website_sessions
+        columns:
+          - name: session_id
+            data_tests:
+              - unique:
+                  config:
+                    severity: error
+                    tags: ['business-rule']
       - name: stg_app_sessions
+        columns:
+          - name: session_id
+            data_tests:
+              - unique:
+                  config:
+                    severity: error
+                    tags: ['business-rule']

--- a/jaffle_shop_online/models/sources.yml
+++ b/jaffle_shop_online/models/sources.yml
@@ -5,3 +5,10 @@ sources:
     schema: jaffle_shop_elementary
     tables:
       - name: elementary_exposures
+        columns:
+          - name: unique_id
+            data_tests:
+              - unique:
+                  config:
+                    severity: error
+                    tags: ['business-rule']


### PR DESCRIPTION
## 🎯 Summary

This PR adds unique tests to all primary keys in source tables to ensure data integrity at the source level.

## 📋 Changes

Added `unique` tests with `severity: error` to the following source tables:
- **stg_facebook_ads**: `ad_id`
- **stg_google_ads**: `ad_id`
- **stg_instagram_ads**: `ad_id`
- **elementary_exposures**: `unique_id`
- **stg_app_sessions**: `session_id`
- **stg_website_sessions**: `session_id`

## ✅ Test Configuration

- **Severity**: `error` - Strict enforcement of primary key uniqueness
- **Tags**: `business-rule` - Marks these as business-critical validation rules
- **Quality Dimension**: Uniqueness

## 🤖 AI Agent

This PR was opened by the Elementary AI Agent

---

*Generated by Elementary AI Assistant*<br><br>Created by: `maayan+172@elementary-data.com`