### PR TITLE
Maayan via Elementary: Fix unit mismatch in historical_orders: convert cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## 🐛 Problem

The `historical_orders` model was storing monetary amounts in **cents** while `real_time_orders` converts them to **dollars**. When these branches are unioned in the `orders` model, historical data was 100× inflated.

This propagated through the data pipeline:
- `orders.amount` (mixed units) → `customer_conversions.revenue` → `attribution_touches.linear_revenue` → `cpa_and_roas.return_on_advertising_spend`

Resulting in the ROAS anomaly detection test failing with 57 consecutive failures.

## ✅ Solution

**historical_orders.sql:**
- Renamed `total_amount` to `amount_cents` in the `final` CTE for clarity
- Applied `cents_to_dollars` macro to all monetary fields using a Jinja loop (matching the pattern in `real_time_orders.sql`)
- Changed `select *` to explicit column selection with conversions

**real_time_orders.sql:**
- Added documentation comment clarifying that all amounts are already in dollars

## 🧪 Testing

After this change:
- Both branches will output amounts in dollars
- The `orders` UNION will have consistent units
- ROAS calculations will be accurate
- The anomaly detection test should resolve

## 📊 Impact

**Fixes incident:** `column_anomalies` on `cpa_and_roas.return_on_advertising_spend` (incident ID: 2924da99-a790-4dcb-b92a-5f9571d1fdce)

**Affected models:**
- ✅ `historical_orders` (critical)
- ✅ `orders` (critical)
- ✅ `customer_conversions`
- ✅ `attribution_touches`
- ✅ `cpa_and_roas` (critical)<br><br>Created by: `maayan+172@elementary-data.com`