### PR TITLE
Maayan via Elementary: Add upstream data quality tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -34,13 +34,14 @@ models:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_payments
     meta:
       owner: "@finance-team"
@@ -59,6 +60,9 @@ models:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_signups
     meta:
       owner: "@customer-team"


### PR DESCRIPTION
This PR adds critical data quality tests to upstream models that feed into the cpa_and_roas calculation:

**stg_orders:**
- Volume anomaly detection to catch pipeline issues
- Freshness anomaly detection to ensure timely data updates

**stg_payments:**
- Volume anomaly detection to monitor payment data quality
- Freshness anomaly detection to validate data freshness

These tests help ensure the integrity of revenue and ROAS calculations by monitoring key data quality metrics at the staging layer.<br><br>Created by: `maayan+172@elementary-data.com`