### PR TITLE
Maayan via Elementary: Fix: Normalize historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,14 +30,22 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount{{ '' if loop.last else ',' }}
+    {% endfor -%}
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+)

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,6 +1,5 @@
-{{
-  config(materialized='view')
-}}
+-- All monetary amounts in this model are in dollars
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -50,4 +49,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+)


### PR DESCRIPTION
## 🐛 Problem

The `return_on_advertising_spend` anomaly test on the `cpa_and_roas` model has been failing with 57 consecutive failures since October 2025.

### Root Cause
The `historical_orders` model was outputting monetary amounts in **cents**, while `real_time_orders` was outputting amounts in **dollars**. When these two datasets are combined via `UNION ALL` in the `orders` model, this created a **100x unit mismatch** that propagated through the entire revenue attribution pipeline:

```
historical_orders (cents) ─┐
                            ├─→ orders → customer_conversions → attribution_touches → cpa_and_roas (ROAS spike)
real_time_orders (dollars) ─┘
```

## ✅ Solution

Normalize `historical_orders` to output all monetary amounts in **dollars** by:
1. Using the existing `cents_to_dollars` macro to convert all monetary fields
2. Renaming the intermediate column to `amount_cents` for clarity
3. Adding a documentation comment to `real_time_orders` to establish the unit convention

## 🧪 Impact

After this fix:
- Both `historical_orders` and `real_time_orders` will output consistent dollar amounts
- The `orders` model will have uniform units
- Revenue calculations in `customer_conversions`, `attribution_touches`, and `cpa_and_roas` will be accurate
- The ROAS anomaly test should return to normal ranges

## 📊 Files Changed

- `models/historical_orders.sql` - Convert cents to dollars for all monetary fields
- `models/real_time_orders.sql` - Add documentation comment<br><br>Created by: `maayan+172@elementary-data.com`