### PR TITLE
Maayan via Elementary: Fix unit mismatch: Normalize historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,4 +1,4 @@
-{{
+{% raw %}{{
   config(materialized='view')
 }}
 
@@ -32,14 +32,22 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount{% if not loop.last %},{% endif %}
+    {% endfor %}
 from final
 where date(order_date) < (
     select date(max(order_date))
     from final
-) 
+){% endraw %}

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+{% raw %}-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}
@@ -50,4 +51,4 @@ select
 from final
 where date(order_date) = (
     select date(max(order_date)) from final
-) 
+){% endraw %}


### PR DESCRIPTION
## 🎯 Problem

The `column_anomalies` test on `return_on_advertising_spend` in the `cpa_and_roas` model has been failing with a **100× spike** in values. Root cause analysis revealed a unit normalization mismatch between the two branches of the `orders` model:

- **real_time_orders**: Converts amounts from cents to dollars using the `cents_to_dollars()` macro
- **historical_orders**: Leaves amounts in cents (raw `total_amount` field)

When these two sources are combined via `UNION ALL`, the mixed units propagate through the entire revenue calculation pipeline, causing the ROAS metric to be artificially inflated when historical data is included.

## 🔧 Changes

### models/historical_orders.sql
- Changed `op.total_amount as amount` to `op.total_amount as amount_cents` for clarity
- Applied `cents_to_dollars()` macro to all monetary fields in the final SELECT:
  - `amount`
  - `credit_card_amount`
  - `coupon_amount`
  - `bank_transfer_amount`
  - `gift_card_amount`
- Updated final SELECT from `select *` to explicit column list to apply conversions

### models/real_time_orders.sql
- Added clarifying comment: `-- All monetary amounts in this model are in dollars`
- No logic changes (already correctly normalized)

## ✅ Impact

This fix ensures:
- **Consistent unit normalization** across both historical and real-time order data
- **Accurate ROAS calculations** in downstream marketing models
- **Resolution of the anomaly test failures** on `cpa_and_roas.return_on_advertising_spend`

## 📊 Affected Models

Downstream models that will benefit from this fix:
- `orders` (direct parent)
- `customer_conversions`
- `attribution_touches`
- `cpa_and_roas` (where the incident was detected)

All affected models execute successfully; this is purely a data accuracy fix.<br><br>Created by: `maayan+172@elementary-data.com`