### PR TITLE
Maayan via Elementary: Fix: Normalize historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -1,6 +1,4 @@
-{{
-  config(materialized='view')
-}}
+{{config(materialized='view')}}
 
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
@@ -32,12 +30,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select 
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting monetary amounts in **cents**, while `real_time_orders` was correctly converting to **dollars**. When these datasets are combined via `UNION ALL` in the `orders` model, this created a **100× magnitude mismatch** that propagated through:

- `customer_conversions.revenue`
- `attribution_touches.linear_revenue`  
- `cpa_and_roas.return_on_advertising_spend`

This mismatch triggered the column anomalies test on `RETURN_ON_ADVERTISING_SPEND`, resulting in incident **2924da99-a790-4dcb-b92a-5f9571d1fdce** with 62 consecutive failures.

## Solution

This PR updates `historical_orders.sql` to match the unit normalization logic in `real_time_orders.sql`:

1. **Rename** `total_amount` to `amount_cents` in the `final` CTE for clarity
2. **Apply** the `cents_to_dollars()` macro to all monetary fields (`amount`, `bank_transfer_amount`, `coupon_amount`, `credit_card_amount`, `gift_card_amount`)
3. **Add explicit column selection** instead of `SELECT *` to match `real_time_orders` structure
4. **Add clarifying comment** to `real_time_orders.sql` documenting that amounts are in dollars

## Testing

After this fix is deployed and the models are rebuilt:
- The `orders` model will have consistent dollar amounts from both historical and real-time sources
- The `return_on_advertising_spend` metric in `cpa_and_roas` will accurately reflect ROAS percentages
- The column anomalies test should pass once the corrected data flows through

## Related

Incident: `2924da99-a790-4dcb-b92a-5f9571d1fdce`<br><br>Created by: `maayan+172@elementary-data.com`