### PR TITLE
Maayan via Elementary: Add upstream data quality tests for cpa_and_roas model

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -34,13 +34,22 @@ models:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+    data_tests:
+      - elementary.volume_anomalies:
+          arguments:
+            timestamp_column: order_date
+            where_expression: order_date >= current_date - 30
+            sensitivity: 3
+            anomaly_direction: both
+      - elementary.freshness_anomalies:
+          arguments:
+            timestamp_column: order_date
+            sensitivity: 3
   - name: stg_payments
     meta:
       owner: "@finance-team"
@@ -59,6 +68,15 @@ models:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
 
+    data_tests:
+      - elementary.volume_anomalies:
+          arguments:
+            where_expression: order_id is not null
+            sensitivity: 3
+            anomaly_direction: both
+      - elementary.freshness_anomalies:
+          arguments:
+            sensitivity: 3
   - name: stg_signups
     meta:
       owner: "@customer-team"


### PR DESCRIPTION
This PR adds critical data quality tests to upstream models that feed into the `cpa_and_roas` marketing performance model:

**stg_orders:**
- Volume anomaly detection to catch unexpected changes in order volumes
- Freshness anomaly detection to ensure timely data updates

**stg_payments:**
- Volume anomaly detection to monitor payment record consistency
- Freshness anomaly detection to validate payment data timeliness

These tests create an early warning system for data quality issues that could impact marketing ROI calculations.<br><br>Created by: `maayan+172@elementary-data.com`