### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` correctly converts to **dollars** using the `cents_to_dollars()` macro. When these are `UNION ALL`'d in the `orders` model, the `amount` column mixes units, causing a ~100× inflation in revenue for historical orders.

This propagates through the pipeline:
`historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

...resulting in wildly inflated **RETURN_ON_ADVERTISING_SPEND** values that trigger the column anomaly test (incident severity: High).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`)
- **`real_time_orders.sql`**: Add clarifying comment that amounts are already in dollars (no logic changes)

## Related

- Elementary Incident: `2924da99-a790-4dcb-b92a-5f9571d1fdce` (High severity, 65 failure events)
- JIRA: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`