### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` outputs them in **dollars**. Both are combined via `UNION ALL` in the `orders` model, causing a **~100× inflation** of historical revenue.

This propagates through:
`historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

...and triggers the `column_anomalies` (average) test on `RETURN_ON_ADVERTISING_SPEND`, which has been failing since October 2025 (65 consecutive failures).

## Fix

- **`historical_orders.sql`**: Apply `{{ cents_to_dollars(...) }}` macro to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`)
- **`real_time_orders.sql`**: Add clarifying comment (no logic changes)

## Related Incident

- Incident: ROAS anomaly on `cpa_and_roas` (HIGH severity, 65 failures)
- JIRA: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`