### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary fields from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` already converts them to **dollars** using the `cents_to_dollars` macro. Both are unioned in the `orders` model, creating a ~100× unit mismatch that propagates through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, inflating the ROAS metric and triggering an ongoing High-severity anomaly detection incident (65 consecutive failures).

## Fix

- **`historical_orders.sql`**: Apply the `cents_to_dollars()` macro to all monetary fields (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`).
- **`real_time_orders.sql`**: Add a clarifying comment noting amounts are already in dollars (no logic change).

## Impact

Once merged and deployed, the `orders` model will have consistent dollar-denominated amounts from both sources, and the ROAS anomaly test on `cpa_and_roas` should return to normal.<br><br>Created by: `maayan+172@elementary-data.com`