### PR TITLE
Maayan via Elementary: fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was exposing monetary amounts in **cents**, while `real_time_orders` already converts them to **dollars** using the `cents_to_dollars` macro. Both models feed into `orders` via `UNION ALL`, mixing cents and dollars in the same `amount` column.

This propagated through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing ROAS to be ~100× inflated for historical orders — triggering the anomaly detection test on `RETURN_ON_ADVERTISING_SPEND`.

## Fix

- **`historical_orders.sql`**: Apply the `cents_to_dollars` macro to all monetary fields (`credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`, and `amount`).
- **`real_time_orders.sql`**: Add a clarifying comment noting that amounts are already in dollars.

## Impact

Resolves incident on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` (High severity, 65 failure events since Oct 2025).<br><br>Created by: `maayan+172@elementary-data.com`