### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents** while `real_time_orders` converts them to **dollars** using the `cents_to_dollars()` macro. Since `orders` unions both models, this creates a **100× mismatch** that propagates through:

`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

This inflates the `RETURN_ON_ADVERTISING_SPEND` metric and has been triggering the column anomaly test since October 2025 (Incident severity: High, 65+ failures).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` to `total_amount` and all payment method amounts, matching the pattern in `real_time_orders.sql`
- **`real_time_orders.sql`**: Add clarifying comment (no logic change)

## Impact

Resolves the ROAS anomaly incident on `cpa_and_roas` (JIRA: JSO-1). All downstream marketing metrics that depend on `orders.amount` will now have consistent dollar-denominated values.<br><br>Created by: `maayan+172@elementary-data.com`