### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `column_anomalies` (average) test on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` has been failing since October 2025 (incident severity: **High**, 65+ failure events).

## Root Cause

`historical_orders.amount` was stored in **cents** while `real_time_orders.amount` was already converted to **dollars** using the `cents_to_dollars()` macro. Both are `UNION ALL`'d in the `orders` model, creating a ~100× unit mismatch that propagates through:

`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND`

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` to all monetary columns (payment method amounts + total amount), matching the pattern in `real_time_orders.sql`
- **`real_time_orders.sql`**: Added a clarifying comment — no logic changes

## Testing

After merge and `dbt run`, the ROAS anomaly test should stabilize as historical and real-time amounts will be in the same unit (dollars).<br><br>Created by: `maayan+172@elementary-data.com`