### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` correctly converts them to **dollars** using the `cents_to_dollars()` macro. Since `orders` unions both models, this unit mismatch causes a ~100× inflation in downstream calculations.

**Impact chain:** `historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas` (ROAS anomaly — 67 consecutive failures)

## Fix

- **`historical_orders.sql`** — Apply `cents_to_dollars()` to all monetary columns (`credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`, `amount`)
- **`real_time_orders.sql`** — Add clarifying comment (no logic change)

## Related

- Incident: ROAS column anomaly on `cpa_and_roas` (High severity, 67 failures)
- Jira: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`