### PR TITLE
Mika Kerman via Elementary: Add not_null test to customers.customer_id

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -2,8 +2,8 @@ version: 2
 
 models:
   - name: customers
-    description: This table has basic information about a customer, as well as some
-      derived facts based on a customer's orders
+    description: This table has basic information about a customer, as well as some derived
+      facts based on a customer's orders
     meta:
       owner: "@customer-team"
     config:
@@ -23,6 +23,9 @@ models:
               to: ref('stg_signups')
               field: customer_id
 
+          - not_null:
+              arguments:
+                column_name: customer_id
       - name: first_name
         description: Customer's first name. PII.
 
@@ -57,8 +60,8 @@ models:
         description: Date (UTC) of a customer's signup to the online shop.
 
   - name: orders
-    description: This table has basic information about orders, as well as some derived
-      facts based on payments
+    description: This table has basic information about orders, as well as some derived facts
+      based on payments
     meta:
       owner: "@sales-team"
     config:
@@ -244,8 +247,8 @@ models:
         description: Amount of the order (AUD) paid for by gift card
 
   - name: order_items
-    description: "Junction table between orders and products, containing the individual
-      line items per order."
+    description: "Junction table between orders and products, containing the individual line
+      items per order."
     meta:
       owner: "@sales-team"
     config:
@@ -261,8 +264,8 @@ models:
         description: "Sale price of a single unit (AUD)"
 
   - name: historical_orders
-    description: "Orders loaded from the historical batch datasets (prior to the current
-      day). Amount fields are stored in cents."
+    description: "Orders loaded from the historical batch datasets (prior to the current day).
+      Amount fields are stored in cents."
     meta:
       owner: "@finance-team"
     config:
@@ -290,9 +293,8 @@ models:
         description: "Portion of the order paid with gift card (in cents)"
 
   - name: real_time_orders
-    description: "Orders ingested from the real-time pipeline for the current day.
-      Monetary fields have already been converted to dollars via the cents_to_dollars
-      macro."
+    description: "Orders ingested from the real-time pipeline for the current day. Monetary
+      fields have already been converted to dollars via the cents_to_dollars macro."
     meta:
       owner: "@finance-team"
     config:


### PR DESCRIPTION
Adds a `not_null` generic test on the `customer_id` column of the `customers` model to ensure the primary key is never null.<br><br>Created by: `mika@elementary-data.com`