### PR TITLE
Maayan via Elementary: fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting monetary amounts in **cents**, while `real_time_orders` correctly converts to **dollars** using the `cents_to_dollars` macro. Both models are `UNION ALL`'d in the `orders` model, causing a **~100× unit mismatch**.

This propagated through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing the **RETURN_ON_ADVERTISING_SPEND** metric to drop from ~65.4 to ~0.23, triggering a column anomaly incident.

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`)
- **`real_time_orders.sql`**: Add clarifying comment (no logic change)

## Impact

This fix will restore correct ROAS calculations for the `cpa_and_roas` model and resolve the open anomaly incident.<br><br>Created by: `maayan+172@elementary-data.com`