### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting monetary amounts in **cents**, while `real_time_orders` was already converting to **dollars** using the `cents_to_dollars()` macro. Both models are `UNION ALL`'d in the `orders` model, creating a ~100× scale mismatch.

This caused the `RETURN_ON_ADVERTISING_SPEND` column in `cpa_and_roas` to be dramatically inflated for historical data, triggering a High-severity anomaly detection incident (68 consecutive failures since Oct 2025).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`).
- **`real_time_orders.sql`**: Added clarifying comment (no logic change).

## Impact

Resolves incident on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` and corrects all downstream metrics that depend on `orders.amount` (including CPA and ROAS calculations).<br><br>Created by: `maayan+172@elementary-data.com`