### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting monetary amounts in **cents** while `real_time_orders` was outputting in **dollars**. Since the `orders` model `UNION ALL`s both, this created a ~100× mismatch that propagated through:

`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

This caused the `RETURN_ON_ADVERTISING_SPEND` column anomaly test to fail continuously (incident open since Oct 2025, 69 failure events).

## Fix

- **`historical_orders.sql`**: Applied the `cents_to_dollars()` macro to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`)
- **`real_time_orders.sql`**: Added a clarifying comment that amounts are already in dollars

## Impact

Resolves the high-severity ROAS anomaly incident on the critical `cpa_and_roas` model owned by @finance-team.<br><br>Created by: `maayan+172@elementary-data.com`