### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting all monetary amounts in **cents** while `real_time_orders` was already converting to **dollars** using the `cents_to_dollars()` macro. Since the `orders` model unions both tables, this created a **100× mismatch** in the `amount` column.

This propagated through the lineage:
`historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

...inflating `RETURN_ON_ADVERTISING_SPEND` and triggering the column anomaly test (incident since Oct 22, 2025, 69 consecutive failures).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary fields, matching the pattern already used in `real_time_orders.sql`
- **`real_time_orders.sql`**: Added clarifying comment (no logic change)

## Related
- Incident: column_anomalies / average on `RETURN_ON_ADVERTISING_SPEND`
- JIRA: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`