### PR TITLE
Maayan via Elementary: Add data contract tests for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -131,31 +131,66 @@ models:
         - "finance-data-product"
       elementary:
         timestamp_column: "day"
+    data_tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: day
+          interval: 1
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - utm_source
     columns:
       - name: day
         data_type: date
         description: "Day (UTC)"
+        data_tests:
+          - not_null
 
       - name: utm_source
         data_type: varchar
         description: "Source where the ad was displayed. For example, Google, Facebook,
           Twitter, Newsletter, etc."
+        data_tests:
+          - not_null
 
       - name: attribution_points
         data_type: number
         description: "Total number of attribution points"
+        data_tests:
+          - not_null
 
       - name: attribution_revenue
         data_type: number
         description: "Total revenue amount (USD)"
+        data_tests:
+          - not_null
 
       - name: total_spend
         data_type: number
         description: "Total spend amount (USD)"
+        data_tests:
+          - not_null
 
       - name: cost_per_acquisition
         data_type: number
         description: "Cost (USD) per acquisition, calculated as total_spend / attribution_points"
+        data_tests:
+          - elementary.column_anomalies:
+              anomaly_direction: both
+              anomaly_sensitivity: 1.5
+              column_anomalies:
+                - average
+              detection_period:
+                count: 2
+                period: day
+              timestamp_column: day
+              training_period:
+                count: 30
+                period: day
+              time_bucket:
+                period: day
+                count: 1
 
       - name: return_on_advertising_spend
         data_type: number


### PR DESCRIPTION
## Data Contract for `cpa_and_roas`

This PR enforces a data contract on the `cpa_and_roas` model with the following guarantees:

### Tests Added

| Requirement | Test | Scope |
|---|---|---|
| **Freshness** | `dbt_utils.recency` | `day` column — data must be no older than 1 day |
| **Completeness** | `not_null` | 5 core columns: `day`, `utm_source`, `total_spend`, `attribution_points`, `attribution_revenue` |
| **Uniqueness** | `dbt_utils.unique_combination_of_columns` | Composite key: `day` + `utm_source` |
| **KPI Anomalies** | `elementary.column_anomalies` | `cost_per_acquisition` (average) — complements existing ROAS anomaly test |

### Notes
- `cost_per_acquisition` and `return_on_advertising_spend` are intentionally excluded from `not_null` tests as they can legitimately be null when spend or attribution points are zero
- The CPA anomaly test mirrors the existing ROAS test configuration (daily buckets, bidirectional detection)
- No existing tests were modified or removed<br><br>Created by: `maayan+172@elementary-data.com`