### PR TITLE
Maayan via Elementary: Add campaign_roi_multi_attribution model

### DIFF
--- a/jaffle_shop_online/models/marketing/campaign_roi_multi_attribution.sql
+++ b/jaffle_shop_online/models/marketing/campaign_roi_multi_attribution.sql
@@ -1,0 +1,133 @@
+{{
+    config(
+        materialized = "table",
+    )
+}}
+
+with ad_spend as (
+
+    select * from {{ ref('ads_spend') }}
+
+),
+
+attribution as (
+
+    select * from {{ ref('attribution_touches') }}
+
+),
+
+sessions as (
+
+    select * from {{ ref('sessions') }}
+
+),
+
+-- Aggregate daily spend by source
+ad_spend_aggregated as (
+
+    select
+        day,
+        utm_source,
+        sum(spend) as total_spend
+
+    from ad_spend
+    group by 1, 2
+
+),
+
+-- Aggregate attribution metrics across all models
+attribution_aggregated as (
+
+    select
+        sess.started_at::date as day,
+        sess.utm_source,
+
+        -- Linear attribution
+        sum(attr.linear_points) as linear_points,
+        sum(attr.linear_revenue) as linear_revenue,
+
+        -- First-touch attribution
+        sum(attr.first_touch_points) as first_touch_points,
+        sum(attr.first_touch_revenue) as first_touch_revenue,
+
+        -- Last-touch attribution
+        sum(attr.last_touch_points) as last_touch_points,
+        sum(attr.last_touch_revenue) as last_touch_revenue,
+
+        -- 40/20/40 attribution
+        sum(attr.forty_twenty_forty_points) as forty_twenty_forty_points,
+        sum(attr.forty_twenty_forty_revenue) as forty_twenty_forty_revenue,
+
+        -- Time-decay attribution
+        sum(attr.time_decay_points) as time_decay_points,
+        sum(attr.time_decay_revenue) as time_decay_revenue
+
+    from attribution attr
+    inner join sessions sess
+        on sess.session_id = attr.session_id
+        and sess.customer_id = attr.customer_id
+
+    group by 1, 2
+
+),
+
+joined as (
+
+    select
+        coalesce(attr_agg.day, spend_agg.day) as day,
+        coalesce(attr_agg.utm_source, spend_agg.utm_source) as utm_source,
+        coalesce(spend_agg.total_spend, 0) as total_spend,
+
+        -- Raw attribution metrics
+        coalesce(attr_agg.linear_points, 0) as linear_points,
+        coalesce(attr_agg.linear_revenue, 0) as linear_revenue,
+        coalesce(attr_agg.first_touch_points, 0) as first_touch_points,
+        coalesce(attr_agg.first_touch_revenue, 0) as first_touch_revenue,
+        coalesce(attr_agg.last_touch_points, 0) as last_touch_points,
+        coalesce(attr_agg.last_touch_revenue, 0) as last_touch_revenue,
+        coalesce(attr_agg.forty_twenty_forty_points, 0) as forty_twenty_forty_points,
+        coalesce(attr_agg.forty_twenty_forty_revenue, 0) as forty_twenty_forty_revenue,
+        coalesce(attr_agg.time_decay_points, 0) as time_decay_points,
+        coalesce(attr_agg.time_decay_revenue, 0) as time_decay_revenue,
+
+        -- ROAS by attribution model
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.linear_revenue, 0) > 0
+            then 1.0 * attr_agg.linear_revenue / spend_agg.total_spend end as linear_roas,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.first_touch_revenue, 0) > 0
+            then 1.0 * attr_agg.first_touch_revenue / spend_agg.total_spend end as first_touch_roas,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.last_touch_revenue, 0) > 0
+            then 1.0 * attr_agg.last_touch_revenue / spend_agg.total_spend end as last_touch_roas,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.forty_twenty_forty_revenue, 0) > 0
+            then 1.0 * attr_agg.forty_twenty_forty_revenue / spend_agg.total_spend end as forty_twenty_forty_roas,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.time_decay_revenue, 0) > 0
+            then 1.0 * attr_agg.time_decay_revenue / spend_agg.total_spend end as time_decay_roas,
+
+        -- CPA by attribution model
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.linear_points, 0) > 0
+            then 1.0 * spend_agg.total_spend / attr_agg.linear_points end as linear_cpa,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.first_touch_points, 0) > 0
+            then 1.0 * spend_agg.total_spend / attr_agg.first_touch_points end as first_touch_cpa,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.last_touch_points, 0) > 0
+            then 1.0 * spend_agg.total_spend / attr_agg.last_touch_points end as last_touch_cpa,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.forty_twenty_forty_points, 0) > 0
+            then 1.0 * spend_agg.total_spend / attr_agg.forty_twenty_forty_points end as forty_twenty_forty_cpa,
+
+        case when coalesce(spend_agg.total_spend, 0) > 0 and coalesce(attr_agg.time_decay_points, 0) > 0
+            then 1.0 * spend_agg.total_spend / attr_agg.time_decay_points end as time_decay_cpa
+
+    from attribution_aggregated attr_agg
+    full outer join ad_spend_aggregated spend_agg
+        on attr_agg.day = spend_agg.day
+        and attr_agg.utm_source = spend_agg.utm_source
+
+)
+
+select * from joined
+order by day, utm_source

--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -313,3 +313,104 @@ models:
       - name: utm_campain
         data_type: varchar
         description: "The name of the advertising campaign"
+
+  - name: campaign_roi_multi_attribution
+    description: "This table contains marketing ROI metrics (ROAS and CPA) calculated across all 5 attribution models (linear, first-touch, last-touch, 40/20/40, and time-decay), broken down by day and utm_source."
+    meta:
+      owner: "@marketing-team"
+    config:
+      tags: ["marketing", "finance", "finance-data-product"]
+      elementary:
+        timestamp_column: "day"
+    columns:
+      - name: day
+        data_type: date
+        description: "Day (UTC)"
+
+      - name: utm_source
+        data_type: varchar
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter, etc."
+
+      - name: total_spend
+        data_type: number
+        description: "Total ad spend amount (USD) for the day and source"
+
+      - name: linear_points
+        data_type: number
+        description: "Attribution points using linear model"
+
+      - name: linear_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using linear model"
+
+      - name: first_touch_points
+        data_type: number
+        description: "Attribution points using first-touch model"
+
+      - name: first_touch_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using first-touch model"
+
+      - name: last_touch_points
+        data_type: number
+        description: "Attribution points using last-touch model"
+
+      - name: last_touch_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using last-touch model"
+
+      - name: forty_twenty_forty_points
+        data_type: number
+        description: "Attribution points using 40/20/40 model"
+
+      - name: forty_twenty_forty_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using 40/20/40 model"
+
+      - name: time_decay_points
+        data_type: number
+        description: "Attribution points using time-decay model"
+
+      - name: time_decay_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using time-decay model"
+
+      - name: linear_roas
+        data_type: number
+        description: "Return on ad spend using linear attribution (linear_revenue / total_spend)"
+
+      - name: first_touch_roas
+        data_type: number
+        description: "Return on ad spend using first-touch attribution"
+
+      - name: last_touch_roas
+        data_type: number
+        description: "Return on ad spend using last-touch attribution"
+
+      - name: forty_twenty_forty_roas
+        data_type: number
+        description: "Return on ad spend using 40/20/40 attribution"
+
+      - name: time_decay_roas
+        data_type: number
+        description: "Return on ad spend using time-decay attribution"
+
+      - name: linear_cpa
+        data_type: number
+        description: "Cost per acquisition using linear attribution (total_spend / linear_points)"
+
+      - name: first_touch_cpa
+        data_type: number
+        description: "Cost per acquisition using first-touch attribution"
+
+      - name: last_touch_cpa
+        data_type: number
+        description: "Cost per acquisition using last-touch attribution"
+
+      - name: forty_twenty_forty_cpa
+        data_type: number
+        description: "Cost per acquisition using 40/20/40 attribution"
+
+      - name: time_decay_cpa
+        data_type: number
+        description: "Cost per acquisition using time-decay attribution"


### PR DESCRIPTION
## Summary\n\nAdds a new marketing model `campaign_roi_multi_attribution` that calculates ROI metrics (ROAS and CPA) across all 5 attribution models side by side.\n\n### Attribution models included:\n- **Linear** — equal credit to all touchpoints\n- **First-touch** — 100% credit to first interaction\n- **Last-touch** — 100% credit to last interaction\n- **40/20/40** — weighted split (first/middle/last)\n- **Time-decay** — more weight to recent touchpoints\n\n### Output metrics per attribution model:\n- ROAS (Return on Ad Spend) = attributed_revenue / total_spend\n- CPA (Cost Per Acquisition) = total_spend / attribution_points\n\n### Files changed:\n- `models/marketing/campaign_roi_multi_attribution.sql` — new model SQL\n- `models/marketing/schema.yml` — schema definition with full column documentation\n\n### Dependencies:\n- `ads_spend`\n- `attribution_touches`\n- `sessions`"<br><br>Created by: `maayan+172@elementary-data.com`