### PR TITLE
Maayan via Elementary: Add campaign_roi model for marketing campaign ROI analysis

### DIFF
--- a/jaffle_shop_online/models/marketing/campaign_roi.sql
+++ b/jaffle_shop_online/models/marketing/campaign_roi.sql
@@ -1,0 +1,103 @@
+{{
+    config(
+        materialized = "table",
+    )
+}}
+
+with ad_spend as (
+
+    select * from {{ ref('ads_spend') }}
+
+),
+
+attribution as (
+
+    select * from {{ ref('attribution_touches') }}
+
+),
+
+sessions as (
+
+    select * from {{ ref('sessions') }}
+
+),
+
+-- Aggregate ad spend by day, source and campaign
+ad_spend_aggregated as (
+
+    select
+        day,
+        utm_source,
+        utm_campain,
+
+        sum(spend) as total_spend
+
+    from ad_spend
+    group by 1, 2, 3
+
+),
+
+-- Aggregate attribution by day, source and campaign
+attribution_aggregated as (
+
+    select
+        sess.started_at::date as day,
+        sess.utm_source,
+        sess.utm_campain,
+
+        sum(attr.linear_points) as attribution_points,
+        sum(attr.linear_revenue) as attribution_revenue
+
+    from attribution attr
+    inner join sessions sess
+        on sess.session_id = attr.session_id
+        and sess.customer_id = attr.customer_id
+
+    group by 1, 2, 3
+
+),
+
+joined as (
+
+    select
+        coalesce(attr_agg.day, spend_agg.day) as day,
+        coalesce(attr_agg.utm_source, spend_agg.utm_source) as utm_source,
+        coalesce(attr_agg.utm_campain, spend_agg.utm_campain) as utm_campain,
+        coalesce(spend_agg.total_spend, 0) as total_spend,
+        coalesce(attr_agg.attribution_points, 0) as attribution_points,
+        coalesce(attr_agg.attribution_revenue, 0) as attribution_revenue,
+
+        -- CPA: cost per acquisition
+        case
+            when coalesce(spend_agg.total_spend, 0) > 0
+                 and coalesce(attr_agg.attribution_points, 0) > 0
+            then 1.0 * spend_agg.total_spend / attr_agg.attribution_points
+            else null
+        end as cost_per_acquisition,
+
+        -- ROAS: return on advertising spend
+        case
+            when coalesce(spend_agg.total_spend, 0) > 0
+                 and coalesce(attr_agg.attribution_revenue, 0) > 0
+            then 1.0 * attr_agg.attribution_revenue / spend_agg.total_spend
+            else null
+        end as return_on_advertising_spend,
+
+        -- ROI %: (revenue - spend) / spend * 100
+        case
+            when coalesce(spend_agg.total_spend, 0) > 0
+                 and coalesce(attr_agg.attribution_revenue, 0) > 0
+            then 100.0 * (attr_agg.attribution_revenue - spend_agg.total_spend) / spend_agg.total_spend
+            else null
+        end as roi_percentage
+
+    from attribution_aggregated attr_agg
+    full outer join ad_spend_aggregated spend_agg
+        on attr_agg.day = spend_agg.day
+        and attr_agg.utm_source = spend_agg.utm_source
+        and attr_agg.utm_campain = spend_agg.utm_campain
+
+)
+
+select * from joined
+order by day, utm_source, utm_campain

--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -178,6 +178,51 @@ models:
                 period: day
                 count: 1
 
+  - name: campaign_roi
+    description: "This table contains the ROI of marketing campaigns, broken down by source, campaign, and day. It calculates CPA, ROAS, and ROI percentage using linear attribution."
+    meta:
+      owner: "@marketing-team"
+    config:
+      tags: ["marketing", "finance", "finance-data-product"]
+      elementary:
+        timestamp_column: "day"
+    columns:
+      - name: day
+        data_type: date
+        description: "Day (UTC)"
+
+      - name: utm_source
+        data_type: varchar
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter, etc."
+
+      - name: utm_campain
+        data_type: varchar
+        description: "The name of the advertising campaign"
+
+      - name: total_spend
+        data_type: number
+        description: "Total ad spend amount (USD) for the campaign on that day"
+
+      - name: attribution_points
+        data_type: number
+        description: "Total attributed conversions (linear model) for the campaign on that day"
+
+      - name: attribution_revenue
+        data_type: number
+        description: "Total attributed revenue (USD, linear model) for the campaign on that day"
+
+      - name: cost_per_acquisition
+        data_type: number
+        description: "Cost (USD) per acquisition, calculated as total_spend / attribution_points"
+
+      - name: return_on_advertising_spend
+        data_type: number
+        description: "Return on advertising spend, calculated as attribution_revenue / total_spend"
+
+      - name: roi_percentage
+        data_type: number
+        description: "ROI percentage, calculated as (attribution_revenue - total_spend) / total_spend * 100"
+
   - name: marketing_ads
     description: "This table contains information on the ad spend, by source, medium
       and campaign"


### PR DESCRIPTION
## Summary\n\nAdds a new `campaign_roi` model to the marketing folder that calculates ROI metrics at the **campaign level** (per day, per source, per campaign).\n\n## What's included\n\n### New model: `campaign_roi`\n- **SQL file**: `models/marketing/campaign_roi.sql`\n- **Schema definition**: Added to `models/marketing/schema.yml`\n\n### Metrics calculated\n| Metric | Formula |\n|---|---|\n| **CPA** (Cost Per Acquisition) | `total_spend / attribution_points` |\n| **ROAS** (Return on Ad Spend) | `attribution_revenue / total_spend` |\n| **ROI %** | `(attribution_revenue - total_spend) / total_spend × 100` |\n\n### Data sources\n- `ads_spend` — daily ad spend by source, medium, and campaign\n- `attribution_touches` — multi-touch attribution data (using linear attribution model)\n- `sessions` — customer session data with UTM tracking\n\n### Design notes\n- Follows the same pattern as the existing `cpa_and_roas` model but adds the `utm_campain` dimension\n- Uses a full outer join to capture campaigns with spend but no conversions (and vice versa)\n- Null-safe calculations: metrics return `null` when denominator is zero\n- Materialized as a table for query performance\n- Tagged with `marketing`, `finance`, and `finance-data-product`\n- Owned by `@marketing-team`<br><br>Created by: `maayan+172@elementary-data.com`