### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting all monetary amounts (including `amount`) in **cents**, while `real_time_orders` already applied the `cents_to_dollars()` macro to convert to **dollars**.

Since the `orders` model does a `UNION ALL` of both, this created a **100× unit mismatch** that propagated through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing the `RETURN_ON_ADVERTISING_SPEND` column anomaly test to fail persistently.

## Fix

- **`historical_orders.sql`**: Applied `cents_to_dollars()` macro to all monetary columns (payment method amounts and total amount), matching the conversion already done in `real_time_orders`.
- **`real_time_orders.sql`**: Added a clarifying comment noting amounts are in dollars (no code changes).

## Impact

Resolves incident [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1) — the High severity ROAS anomaly on `cpa_and_roas` that has been firing since October 2025.<br><br>Created by: `maayan+172@elementary-data.com`