### PR TITLE
Maayan via Elementary: Add campaign_roi model for marketing campaign ROI analysis

### DIFF
--- a/jaffle_shop_online/models/marketing/campaign_roi.sql
+++ b/jaffle_shop_online/models/marketing/campaign_roi.sql
@@ -1,0 +1,126 @@
+{{
+    config(
+        materialized = "table",
+    )
+}}
+
+with ad_spend as (
+
+    select * from {{ ref('ads_spend') }}
+
+),
+
+attribution as (
+
+    select * from {{ ref('attribution_touches') }}
+
+),
+
+sessions as (
+
+    select * from {{ ref('sessions') }}
+
+),
+
+-- Aggregate spend by day, source, medium, and campaign
+ad_spend_by_campaign as (
+
+    select
+        day,
+        utm_source,
+        utm_medium,
+        utm_campain,
+
+        sum(spend) as total_spend
+
+    from ad_spend
+    group by 1, 2, 3, 4
+
+),
+
+-- Aggregate attribution by day, source, medium, and campaign
+attribution_by_campaign as (
+
+    select
+        sess.started_at::date as day,
+        sess.utm_source,
+        sess.utm_medium,
+        sess.utm_campain,
+
+        count(distinct attr.customer_id) as unique_customers,
+        count(distinct attr.order_id) as total_conversions,
+        sum(attr.linear_points) as attribution_points,
+        sum(attr.linear_revenue) as attribution_revenue,
+        sum(attr.first_touch_revenue) as first_touch_revenue,
+        sum(attr.last_touch_revenue) as last_touch_revenue,
+        sum(attr.time_decay_revenue) as time_decay_revenue
+
+    from attribution attr
+    inner join sessions sess
+        on sess.session_id = attr.session_id
+        and sess.customer_id = attr.customer_id
+    group by 1, 2, 3, 4
+
+),
+
+joined as (
+
+    select
+        coalesce(attr.day, spend.day) as day,
+        coalesce(attr.utm_source, spend.utm_source) as utm_source,
+        coalesce(attr.utm_medium, spend.utm_medium) as utm_medium,
+        coalesce(attr.utm_campain, spend.utm_campain) as utm_campain,
+
+        -- Spend
+        coalesce(spend.total_spend, 0) as total_spend,
+
+        -- Attribution metrics
+        coalesce(attr.unique_customers, 0) as unique_customers,
+        coalesce(attr.total_conversions, 0) as total_conversions,
+        coalesce(attr.attribution_points, 0) as attribution_points,
+        coalesce(attr.attribution_revenue, 0) as attribution_revenue,
+
+        -- ROI = (Revenue - Cost) / Cost
+        case
+            when coalesce(spend.total_spend, 0) > 0
+            then (coalesce(attr.attribution_revenue, 0) - spend.total_spend) / spend.total_spend
+            else null
+        end as roi,
+
+        -- ROAS = Revenue / Cost
+        case
+            when coalesce(spend.total_spend, 0) > 0
+            then 1.0 * coalesce(attr.attribution_revenue, 0) / spend.total_spend
+            else null
+        end as roas,
+
+        -- CPA = Cost / Conversions
+        case
+            when coalesce(attr.attribution_points, 0) > 0
+            then 1.0 * spend.total_spend / attr.attribution_points
+            else null
+        end as cost_per_acquisition,
+
+        -- Revenue per conversion
+        case
+            when coalesce(attr.total_conversions, 0) > 0
+            then 1.0 * coalesce(attr.attribution_revenue, 0) / attr.total_conversions
+            else null
+        end as revenue_per_conversion,
+
+        -- Multi-model revenue for comparison
+        coalesce(attr.first_touch_revenue, 0) as first_touch_revenue,
+        coalesce(attr.last_touch_revenue, 0) as last_touch_revenue,
+        coalesce(attr.time_decay_revenue, 0) as time_decay_revenue
+
+    from attribution_by_campaign attr
+    full outer join ad_spend_by_campaign spend
+        on attr.day = spend.day
+        and attr.utm_source = spend.utm_source
+        and attr.utm_medium = spend.utm_medium
+        and attr.utm_campain = spend.utm_campain
+
+)
+
+select * from joined
+order by day desc, utm_source, utm_medium, utm_campain

--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -313,3 +313,76 @@ models:
       - name: utm_campain
         data_type: varchar
         description: "The name of the advertising campaign"
+
+  - name: campaign_roi
+    description: "This table contains campaign-level ROI metrics including ROI, ROAS, CPA, and revenue per conversion, broken down by day, source, medium, and campaign. Supports multi-attribution model comparison."
+    meta:
+      owner: "@marketing-team"
+    config:
+      tags: ["marketing", "finance", "finance-data-product"]
+      elementary:
+        timestamp_column: "day"
+    columns:
+      - name: day
+        data_type: date
+        description: "Day (UTC) of the campaign activity"
+
+      - name: utm_source
+        data_type: varchar
+        description: "Source where the ad was displayed (e.g. Google, Facebook, Twitter)"
+
+      - name: utm_medium
+        data_type: varchar
+        description: "The advertising or marketing medium (e.g. social, banners, CPC)"
+
+      - name: utm_campain
+        data_type: varchar
+        description: "The name of the advertising campaign"
+
+      - name: total_spend
+        data_type: number
+        description: "Total spend amount (USD) for the campaign on this day"
+
+      - name: unique_customers
+        data_type: number
+        description: "Number of unique customers attributed to this campaign"
+
+      - name: total_conversions
+        data_type: number
+        description: "Total number of conversions (orders) attributed to this campaign"
+
+      - name: attribution_points
+        data_type: number
+        description: "Total attribution points using linear attribution model"
+
+      - name: attribution_revenue
+        data_type: number
+        description: "Total attributed revenue (USD) using linear attribution model"
+
+      - name: roi
+        data_type: number
+        description: "Return on Investment, calculated as (attribution_revenue - total_spend) / total_spend"
+
+      - name: roas
+        data_type: number
+        description: "Return on Advertising Spend, calculated as attribution_revenue / total_spend"
+
+      - name: cost_per_acquisition
+        data_type: number
+        description: "Cost per acquisition (USD), calculated as total_spend / attribution_points"
+
+      - name: revenue_per_conversion
+        data_type: number
+        description: "Average revenue per conversion (USD), calculated as attribution_revenue / total_conversions"
+
+      - name: first_touch_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using first-touch attribution model"
+
+      - name: last_touch_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using last-touch attribution model"
+
+      - name: time_decay_revenue
+        data_type: number
+        description: "Attributed revenue (USD) using time-decay attribution model"


### PR DESCRIPTION
## 📊 New Model: `campaign_roi`

This PR adds a new dbt model `campaign_roi` that calculates campaign-level marketing ROI metrics.

### What's included
- **New SQL model** at `models/marketing/campaign_roi.sql`
- **Full schema definition** with column descriptions in `models/marketing/schema.yml`

### Key metrics calculated
| Metric | Formula |
|--------|---------|
| **ROI** | `(attribution_revenue - total_spend) / total_spend` |
| **ROAS** | `attribution_revenue / total_spend` |
| **CPA** | `total_spend / attribution_points` |
| **Revenue per conversion** | `attribution_revenue / total_conversions` |

### Granularity
Day × `utm_source` × `utm_medium` × `utm_campain`

### Dependencies
- `ads_spend` — daily ad spend aggregation
- `attribution_touches` — multi-touch attribution touchpoints
- `sessions` — customer sessions with UTM tracking

### Multi-attribution support
Includes revenue columns for **linear**, **first-touch**, **last-touch**, and **time-decay** attribution models for side-by-side comparison.

### Tags & ownership
- Owner: `@marketing-team`
- Tags: `marketing`, `finance`, `finance-data-product`<br><br>Created by: `maayan+172@elementary-data.com`