### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary fields from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary fields (`amount`, `credit_card_amount`, etc.) in **cents**, while `real_time_orders` converts them to **dollars** using the `cents_to_dollars()` macro.

When these are unioned in the `orders` model, historical amounts are **100× inflated**, causing the `RETURN_ON_ADVERTISING_SPEND` anomaly test on `cpa_and_roas` to fail (incident ongoing since Oct 2025).

## Root Cause Trace

`cpa_and_roas` → `attribution_touches` → `customer_conversions` → `orders` → **`historical_orders`** (cents) ∪ `real_time_orders` (dollars)

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns in the `final` CTE, matching the pattern in `real_time_orders.sql`.
- **`real_time_orders.sql`**: Add clarifying comment that amounts are in dollars (no logic change).

## Related

- Incident: Column anomalies (average) on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND`
- JIRA: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`