### PR TITLE
Maayan via Elementary: fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` outputs them in **dollars** (using the `cents_to_dollars()` macro). When these are `UNION ALL`'d in the `orders` model, historical amounts are **100× too large**.

This mismatch propagates through the pipeline:
`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

...causing the **RETURN_ON_ADVERTISING_SPEND** column anomaly test to flag large deviations (incident severity: High, 69 failure events since Oct 2025).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`)
- **`real_time_orders.sql`**: Add clarifying comment that amounts are already in dollars

## Impact

Once merged and deployed, the ROAS values in `cpa_and_roas` should return to normal and the anomaly test should resolve.<br><br>Created by: `maayan+172@elementary-data.com`