### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\n\nThe `historical_orders` model was outputting monetary amounts in **cents** while `real_time_orders` outputs them in **dollars**. Since the `orders` model unions both via `UNION ALL`, this created a ~100× mismatch in the `amount` column for historical records.\n\nThis propagated through the pipeline:\n`historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`\n\n...causing the `RETURN_ON_ADVERTISING_SPEND` anomaly test to fail with inflated ROAS values (incident has been failing for 69 consecutive runs).\n\n## Fix\n\n- **`historical_orders.sql`**: Apply the `cents_to_dollars` macro to all monetary columns, matching the pattern already used in `real_time_orders.sql`\n- **`real_time_orders.sql`**: Add a clarifying comment that amounts are in dollars (no logic changes)\n\n## Impact\n\nThis fix will normalize all monetary values to dollars across both order sources, resolving the ROAS anomaly on `cpa_and_roas`.<br><br>Created by: `maayan+172@elementary-data.com`