### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\n\nThe `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` correctly converts them to **dollars** using the `cents_to_dollars()` macro. Since the `orders` model does a `UNION ALL` of both, the `amount` column contains a mix of cents and dollars.\n\nThis propagates through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, inflating the `RETURN_ON_ADVERTISING_SPEND` metric by ~100× for historical orders and triggering an anomaly detection incident.\n\n## Fix\n\n- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns, matching the pattern in `real_time_orders.sql`\n- **`real_time_orders.sql`**: Add a clarifying comment (no logic changes)\n\n## Related\n\n- Incident: column_anomalies average test failure on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND`\n- JIRA: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)"<br><br>Created by: `maayan+172@elementary-data.com`