### PR TITLE
Maayan via Elementary: Add no-empty-values test for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/tests/test_cpa_and_roas_no_empty_values.sql
+++ b/jaffle_shop_online/tests/test_cpa_and_roas_no_empty_values.sql
@@ -1,0 +1,15 @@
+{{
+    config(
+        meta={'description': 'Validates that attribution_revenue and utm_source columns in cpa_and_roas never contain NULL values'},
+        tags=['finance', 'marketing'],
+        severity='error'
+    )
+}}
+
+-- This test validates that attribution_revenue and utm_source in cpa_and_roas contain no empty (NULL) values.
+
+SELECT *
+FROM {{ ref('cpa_and_roas') }}
+WHERE
+    attribution_revenue IS NULL
+    OR utm_source IS NULL


### PR DESCRIPTION
## Summary\n\nAdds a singular SQL test (`test_cpa_and_roas_no_empty_values`) that validates the `attribution_revenue` and `utm_source` columns in the `cpa_and_roas` model never contain NULL values.\n\n### Why\nThese are core columns in a critical finance/marketing model. `utm_source` identifies the ad source and `attribution_revenue` feeds the ROAS calculation — neither should ever be empty.\n\n### Test details\n- **Type:** Singular SQL test\n- **Severity:** Error\n- **Tags:** `finance`, `marketing`<br><br>Created by: `maayan+172@elementary-data.com`