### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\n\nThe `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` already converts to **dollars** using the `cents_to_dollars()` macro. Since the `orders` model unions both via `UNION ALL`, this causes a ~100× inflation in revenue for historical records.\n\nThis mismatch propagates through:\n`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`\n\n…and triggers the **column_anomalies (average)** test on `RETURN_ON_ADVERTISING_SPEND` (incident ongoing since Oct 2025, 69 consecutive failures).\n\n## Fix\n\n- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns, matching the pattern already used in `real_time_orders.sql`.\n- **`real_time_orders.sql`**: Add a clarifying comment (no logic changes).\n\n## Impact\n\nThis will correct the ROAS and CPA calculations in `cpa_and_roas` and should resolve the ongoing High-severity anomaly incident.<br><br>Created by: `maayan+172@elementary-data.com`