### PR TITLE
Maayan via Elementary: Add volume and freshness anomaly tests for stg_orders and stg_payments

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -34,13 +34,14 @@ models:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_payments
     meta:
       owner: "@finance-team"
@@ -59,6 +60,9 @@ models:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_signups
     meta:
       owner: "@customer-team"


### PR DESCRIPTION
## Summary\n\nAdds upstream test coverage for the `cpa_and_roas` lineage by adding volume and freshness anomaly detection tests to the staging models `stg_orders` and `stg_payments`.\n\n### Tests added:\n- **stg_orders**: `elementary.volume_anomalies` and `elementary.freshness_anomalies`\n- **stg_payments**: `elementary.volume_anomalies` and `elementary.freshness_anomalies`\n\n### Why?\nThese staging models feed into `orders` → `customer_conversions` → `cpa_and_roas`. Without volume and freshness monitoring at this layer, stale or missing data can silently corrupt CPA and ROAS calculations.<br><br>Created by: `maayan+172@elementary-data.com`