### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting monetary fields (`amount`, `credit_card_amount`, etc.) in **cents**, while `real_time_orders` already converts them to **dollars** using the `cents_to_dollars` macro. Since the `orders` model unions both with `UNION ALL`, this created a ~100× scale mismatch that propagated through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing the ROAS anomaly detection test to fail.

## Fix

- **`historical_orders.sql`**: Apply the `cents_to_dollars` macro to all monetary columns in the `final` CTE, matching the pattern already used in `real_time_orders`.
- **`real_time_orders.sql`**: Added a clarifying comment noting that all amounts are in dollars.

## Related Incident

- **Incident**: column_anomalies average test on `RETURN_ON_ADVERTISING_SPEND` (cpa_and_roas)
- **Severity**: High
- **JIRA**: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`