### PR TITLE
Maayan via Elementary: Add anomaly detection tests for key KPIs in cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -16,13 +16,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -33,8 +33,8 @@ models:
         description: "The USD amount of money spent"
 
   - name: attribution_touches
-    description: "This is a table that contains all the touch points, by session,
-      with the utm_source, utm_medium and utm_campaign"
+    description: "This is a table that contains all the touch points, by session, with the utm_source,
+      utm_medium and utm_campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -60,13 +60,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -121,8 +121,8 @@ models:
         description: ""
 
   - name: cpa_and_roas
-    description: "This table contains the cost per acquisition and return on ad spend,
-      by source, and per day"
+    description: "This table contains the cost per acquisition and return on ad spend, by source, and
+      per day"
     meta:
       owner: "@finance-team"
     config:
@@ -138,8 +138,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: attribution_points
         data_type: number
@@ -149,18 +149,68 @@ models:
         data_type: number
         description: "Total revenue amount (USD)"
 
+        data_tests:
+          - elementary.column_anomalies:
+              arguments:
+                column_anomalies:
+                  - average
+                timestamp_column: day
+                anomaly_direction: both
+                anomaly_sensitivity: 2
+                time_bucket:
+                  period: day
+                  count: 1
+                training_period:
+                  period: day
+                  count: 14
+                detection_period:
+                  period: day
+                  count: 2
       - name: total_spend
         data_type: number
         description: "Total spend amount (USD)"
 
+        data_tests:
+          - elementary.column_anomalies:
+              arguments:
+                column_anomalies:
+                  - average
+                timestamp_column: day
+                anomaly_direction: both
+                anomaly_sensitivity: 2
+                time_bucket:
+                  period: day
+                  count: 1
+                training_period:
+                  period: day
+                  count: 14
+                detection_period:
+                  period: day
+                  count: 2
       - name: cost_per_acquisition
         data_type: number
         description: "Cost (USD) per acquisition, calculated as total_spend / attribution_points"
 
+        data_tests:
+          - elementary.column_anomalies:
+              arguments:
+                column_anomalies:
+                  - average
+                timestamp_column: day
+                anomaly_direction: both
+                anomaly_sensitivity: 2
+                time_bucket:
+                  period: day
+                  count: 1
+                training_period:
+                  period: day
+                  count: 14
+                detection_period:
+                  period: day
+                  count: 2
       - name: return_on_advertising_spend
         data_type: number
-        description: "The ROI of the ad spend, calculated as attribution_revenue /
-          total_spend"
+        description: "The ROI of the ad spend, calculated as attribution_revenue / total_spend"
         data_tests:
           - elementary.column_anomalies:
               anomaly_direction: both
@@ -179,8 +229,7 @@ models:
                 count: 1
 
   - name: marketing_ads
-    description: "This table contains information on the ad spend, by source, medium
-      and campaign"
+    description: "This table contains information on the ad spend, by source, medium and campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -198,8 +247,8 @@ models:
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -211,8 +260,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
@@ -241,8 +290,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: ad_id
         data_type: varchar
@@ -250,8 +299,8 @@ models:
 
       - name: platform
         data_type: varchar
-        description: "Platform where the session was made. For example, website, iOS
-          app, Android app, etc."
+        description: "Platform where the session was made. For example, website, iOS app, Android app,
+          etc."
 
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
@@ -275,8 +324,8 @@ models:
         description: "Total revenue amount (USD) of the conversion"
 
   - name: sessions
-    description: "This table contains information on the sessions of all the customers
-      and the utm_source, utm_medium and utm_campaign of the session"
+    description: "This table contains information on the sessions of all the customers and the utm_source,
+      utm_medium and utm_campaign of the session"
     meta:
       owner: "@marketing-team"
     config:
@@ -302,13 +351,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar


### PR DESCRIPTION
This PR adds `elementary.column_anomalies` tests to three key financial KPI columns in the `cpa_and_roas` model:\n\n- **`cost_per_acquisition`** — monitors average CPA for anomalies\n- **`total_spend`** — monitors average spend for anomalies\n- **`attribution_revenue`** — monitors average revenue for anomalies\n\nThese complement the existing anomaly test on `return_on_advertising_spend`, providing full anomaly detection coverage across all key metrics in this critical finance model.\n\n**Configuration** matches the existing test style: sensitivity 2, both spike/drop detection, daily time bucket, 2-day detection period, 14-day training period.<br><br>Created by: `maayan+172@elementary-data.com`