### PR TITLE
Joost Boonzajer Flaes via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\n\nThe `historical_orders` model outputs all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`) in **cents**, while `real_time_orders` already converts them to **dollars** using the `cents_to_dollars` macro.\n\nSince the `orders` model unions both tables, this creates a **100× scale mismatch** in the `amount` column, which propagates through:\n`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`\n\nThis causes the `RETURN_ON_ADVERTISING_SPEND` anomaly test to fail continuously (incident with 71+ failure events since Oct 2025).\n\n## Fix\n\n- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns, matching the pattern in `real_time_orders`.\n- **`real_time_orders.sql`**: Add a clarifying comment (no logic changes).\n\n## Related\n\n- Incident: column_anomalies - Average on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` (HIGH severity)\n- JIRA: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)"<br><br>Created by: `joost@elementary-data.com`