### PR TITLE
Joost Boonzajer Flaes via Elementary: Add volume and freshness anomaly tests for stg_orders and stg_payments

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -34,13 +34,14 @@ models:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_payments
     meta:
       owner: "@finance-team"
@@ -59,6 +60,9 @@ models:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_signups
     meta:
       owner: "@customer-team"


### PR DESCRIPTION
## Summary\n\nAdds volume and freshness anomaly detection tests to `stg_orders` and `stg_payments` to improve upstream coverage for the critical `cpa_and_roas` model.\n\n### Tests Added\n\n**stg_orders:**\n- `elementary.volume_anomalies` — Detects sudden drops or spikes in order volume that would silently distort CPA/ROAS calculations.\n- `elementary.freshness_anomalies` — Catches stale order data before it causes misleading marketing performance metrics.\n\n**stg_payments:**\n- `elementary.volume_anomalies` — Monitors payment record volume to prevent undercounting revenue.\n- `elementary.freshness_anomalies` — Ensures payment data stays current to maintain accurate ROAS reporting.<br><br>Created by: `joost@elementary-data.com`