### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts (`amount`, `credit_card_amount`, etc.) in **cents**, while `real_time_orders` converts them to **dollars** using the `cents_to_dollars()` macro. When these are `UNION ALL`'d in the `orders` model, the mixed units cause a ~100× inflation in revenue that propagates through:

`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

This is the root cause of the persistent **RETURN_ON_ADVERTISING_SPEND** anomaly incident (HIGH severity, ongoing since Oct 2025).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` to all monetary columns, matching `real_time_orders`.
- **`real_time_orders.sql`**: Add clarifying comment (no logic change).

## Impact

Once merged and rebuilt, the ROAS metric in `cpa_and_roas` will return to normal values and the anomaly incident should resolve.<br><br>Created by: `maayan+172@elementary-data.com`