### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents** while `real_time_orders` outputs them in **dollars**. Both are unioned in the `orders` model, causing a **100× mismatch** that propagates through:

`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`

This triggered the **column_anomalies** (average) test on `RETURN_ON_ADVERTISING_SPEND` — incident [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1).

## Fix

- **`historical_orders.sql`**: Apply the `cents_to_dollars()` macro to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`), matching the pattern already used in `real_time_orders.sql`.
- **`real_time_orders.sql`**: Add a clarifying comment noting amounts are in dollars (no logic change).

## Validation

After merging, the `column_anomalies` test on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` should return to normal within one detection period.<br><br>Created by: `maayan+172@elementary-data.com`