### PR TITLE
Joost Boonzajer Flaes via Elementary: Add volume anomaly tests to staging models

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,10 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
     columns:
       - name: order_id
         tests:
@@ -46,6 +50,10 @@ models:
       owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
## Summary\n\nAdds volume anomaly tests to `stg_orders` and `stg_payments` to improve upstream coverage for the critical `cpa_and_roas` model.\n\n### Changes\n- **`stg_orders`**: Added `elementary.volume_anomalies` test to detect sudden drops or spikes in row count that could silently reduce the number of orders flowing into downstream financial models.\n- **`stg_payments`**: Added `elementary.volume_anomalies` test to monitor payment volume, since payment records determine the `amount` column used in revenue and ROAS calculations.\n\n### Why\nBoth staging models feed into the critical `cpa_and_roas` model (via `orders` → `customer_conversions` → `cpa_and_roas`). Without volume monitoring, data ingestion failures could go undetected and corrupt CPA and ROAS metrics.<br><br>Created by: `joost@elementary-data.com`