### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,20 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount_cents') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting monetary amounts in **cents**, while `real_time_orders` was already converting to **dollars** using the `cents_to_dollars()` macro. Since the `orders` model unions both via `UNION ALL`, this created a unit mismatch in the `amount` column.

This propagated through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, inflating the **RETURN_ON_ADVERTISING_SPEND** metric by ~100x and triggering ongoing anomaly detection failures (74 consecutive failures since Oct 2025).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` to all monetary columns, matching the existing pattern in `real_time_orders.sql`.
- **`real_time_orders.sql`**: Added clarifying comment — no logic changes.

## Related Incident

- Incident: column_anomalies (average) on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND`
- Severity: HIGH
- Jira: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`