### PR TITLE
Maayan via Elementary: feat: Add test coverage for cpa_and_roas (JSO-40)

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -16,13 +16,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -33,8 +33,8 @@ models:
         description: "The USD amount of money spent"
 
   - name: attribution_touches
-    description: "This is a table that contains all the touch points, by session,
-      with the utm_source, utm_medium and utm_campaign"
+    description: "This is a table that contains all the touch points, by session, with the utm_source,
+      utm_medium and utm_campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -60,13 +60,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -121,8 +121,8 @@ models:
         description: ""
 
   - name: cpa_and_roas
-    description: "This table contains the cost per acquisition and return on ad spend,
-      by source, and per day"
+    description: "This table contains the cost per acquisition and return on ad spend, by source, and
+      per day"
     meta:
       owner: "@finance-team"
     config:
@@ -136,31 +136,102 @@ models:
         data_type: date
         description: "Day (UTC)"
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: day
+              config:
+                severity: warn
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: utm_source
+              config:
+                severity: warn
       - name: attribution_points
         data_type: number
         description: "Total number of attribution points"
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: attribution_points
+              config:
+                severity: warn
       - name: attribution_revenue
         data_type: number
         description: "Total revenue amount (USD)"
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: attribution_revenue
+              config:
+                severity: warn
+          - elementary.column_anomalies:
+              arguments:
+                column_anomalies:
+                  - average
+                anomaly_direction: both
+                anomaly_sensitivity: 2
+                detection_period:
+                  count: 2
+                  period: day
+                timestamp_column: day
+                training_period:
+                  count: 14
+                  period: day
+                time_bucket:
+                  period: day
+                  count: 1
+              config:
+                severity: warn
       - name: total_spend
         data_type: number
         description: "Total spend amount (USD)"
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: total_spend
+              config:
+                severity: warn
       - name: cost_per_acquisition
         data_type: number
         description: "Cost (USD) per acquisition, calculated as total_spend / attribution_points"
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: cost_per_acquisition
+              config:
+                severity: warn
+          - elementary.column_anomalies:
+              arguments:
+                column_anomalies:
+                  - average
+                anomaly_direction: both
+                anomaly_sensitivity: 2
+                detection_period:
+                  count: 2
+                  period: day
+                timestamp_column: day
+                training_period:
+                  count: 14
+                  period: day
+                time_bucket:
+                  period: day
+                  count: 1
+              config:
+                severity: warn
       - name: return_on_advertising_spend
         data_type: number
-        description: "The ROI of the ad spend, calculated as attribution_revenue /
-          total_spend"
+        description: "The ROI of the ad spend, calculated as attribution_revenue / total_spend"
         data_tests:
           - elementary.column_anomalies:
               anomaly_direction: both
@@ -178,9 +249,28 @@ models:
                 period: day
                 count: 1
 
+          - not_null:
+              arguments:
+                column_name: return_on_advertising_spend
+              config:
+                severity: warn
+    data_tests:
+      - dbt_utils.recency:
+          arguments:
+            datepart: day
+            field: day
+            interval: 1
+          config:
+            severity: warn
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - day
+              - utm_source
+          config:
+            severity: warn
   - name: marketing_ads
-    description: "This table contains information on the ad spend, by source, medium
-      and campaign"
+    description: "This table contains information on the ad spend, by source, medium and campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -198,8 +288,8 @@ models:
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -211,8 +301,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
@@ -241,8 +331,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: ad_id
         data_type: varchar
@@ -250,8 +340,8 @@ models:
 
       - name: platform
         data_type: varchar
-        description: "Platform where the session was made. For example, website, iOS
-          app, Android app, etc."
+        description: "Platform where the session was made. For example, website, iOS app, Android app,
+          etc."
 
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
@@ -275,8 +365,8 @@ models:
         description: "Total revenue amount (USD) of the conversion"
 
   - name: sessions
-    description: "This table contains information on the sessions of all the customers
-      and the utm_source, utm_medium and utm_campaign of the session"
+    description: "This table contains information on the sessions of all the customers and the utm_source,
+      utm_medium and utm_campaign of the session"
     meta:
       owner: "@marketing-team"
     config:
@@ -302,13 +392,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar


### PR DESCRIPTION
## JSO-40: Test coverage on cpa_and_roas

This PR enforces a data contract on the `cpa_and_roas` table with the following tests:

### Freshness
- `dbt_utils.recency` on `day` column – ensures data is updated up until yesterday

### Completeness (no empty values)
- `not_null` on all 7 columns: `day`, `utm_source`, `attribution_points`, `attribution_revenue`, `total_spend`, `cost_per_acquisition`, `return_on_advertising_spend`

### Uniqueness (no duplications)
- `dbt_utils.unique_combination_of_columns` on (`day`, `utm_source`) – validates the natural grain of the table

### Anomaly detection on key business KPIs
- `elementary.column_anomalies` on `cost_per_acquisition` (average)
- `elementary.column_anomalies` on `attribution_revenue` (average)

All new tests are set to severity **warning**.

Resolves: JSO-40<br><br>Created by: `maayan+172@elementary-data.com`