### PR TITLE
Maayan via Elementary: Add upstream tests for cpa_and_roas pipeline

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -34,13 +34,18 @@ models:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+    data_tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
   - name: stg_payments
     meta:
       owner: "@finance-team"
@@ -59,6 +64,13 @@ models:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
 
+    data_tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
   - name: stg_signups
     meta:
       owner: "@customer-team"


### PR DESCRIPTION
## Upstream Test Coverage for `cpa_and_roas`

Adds volume and freshness anomaly tests to staging models that feed into the `cpa_and_roas` pipeline:

### `stg_orders` (5-level upstream)
- **Volume anomaly** — Detects sudden drops or spikes in row count that would cascade through `real_time_orders` → `orders` → `cpa_and_roas`
- **Freshness anomaly** — Ensures the staging layer receives timely updates to keep the real-time pipeline current

### `stg_payments` (5-level upstream)
- **Volume anomaly** — Missing payment records would cause zero-value amounts, distorting ROAS figures
- **Freshness anomaly** — Stale payment data leads to incomplete monetary calculations downstream<br><br>Created by: `maayan+172@elementary-data.com`