### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was exposing monetary amounts in **cents** while `real_time_orders` already converts them to **dollars** using the `cents_to_dollars()` macro. Since both models are combined via `UNION ALL` in the `orders` model, this unit mismatch caused:

- **~100× inflation** in revenue for historical orders
- Propagation through `customer_conversions` → `attribution_touches` → `cpa_and_roas`
- Persistent anomaly detection failures on the `RETURN_ON_ADVERTISING_SPEND` column (74 failure events since Oct 2025)

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns (amount, credit_card_amount, coupon_amount, bank_transfer_amount, gift_card_amount)
- **`real_time_orders.sql`**: Added clarifying comment (no logic changes)

## Impact

This resolves incident `2924da99-a790-4dcb-b92a-5f9571d1fdce` (HIGH severity, ACKNOWLEDGED) on the critical `cpa_and_roas` model owned by @finance-team.<br><br>Created by: `maayan+172@elementary-data.com`