### PR TITLE
Maayan via Elementary: Optimize agg_sessions: explicit columns & incremental filter

### DIFF
--- a/jaffle_shop_online/models/marketing/agg_sessions.sql
+++ b/jaffle_shop_online/models/marketing/agg_sessions.sql
@@ -6,17 +6,49 @@
 }}
 
 with app_sessions as (
-    select *
+    select
+        session_id,
+        customer_id,
+        ad_id,
+        started_at,
+        ended_at,
+        utm_source
     from {{ source("sessions", "stg_app_sessions") }}
+    {% if is_incremental() %}
+        where started_at > (select max(started_at) from {{ this }})
+    {% endif %}
 ),
 
 website_sessions as (
-    select *
+    select
+        session_id,
+        customer_id,
+        ad_id,
+        started_at,
+        ended_at,
+        utm_source
     from {{ source("sessions", "stg_website_sessions") }}
+    {% if is_incremental() %}
+        where started_at > (select max(started_at) from {{ this }})
+    {% endif %}
 )
 
-select *, 'app' as platform
+select
+    session_id,
+    customer_id,
+    ad_id,
+    started_at,
+    ended_at,
+    utm_source,
+    'app' as platform
 from app_sessions
 union all
-select *, 'website' as platform
+select
+    session_id,
+    customer_id,
+    ad_id,
+    started_at,
+    ended_at,
+    utm_source,
+    'website' as platform
 from website_sessions


### PR DESCRIPTION
## Summary\n\nThis PR optimizes the `agg_sessions` incremental model with two key changes:\n\n### Changes\n\n1. **Replaced `SELECT *` with explicit column selection** — Only the 6 required columns (`session_id`, `customer_id`, `ad_id`, `started_at`, `ended_at`, `utm_source`) are now selected, reducing I/O and protecting against upstream schema changes.\n\n2. **Added `{% if is_incremental() %}` filter** — On incremental runs, only new sessions (based on `started_at`) are processed instead of full-scanning both source tables. This should significantly reduce execution time from the current ~186s.\n\n### Impact\n- Reduced warehouse I/O costs\n- Faster incremental runs\n- More resilient to upstream schema changes<br><br>Created by: `maayan+172@elementary-data.com`