### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' ~ payment_method ~ '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs all monetary fields (`amount`, `credit_card_amount`, etc.) in **cents**, while `real_time_orders` already converts them to **dollars** using the `cents_to_dollars()` macro.

Both models are `UNION ALL`'d in the `orders` model, creating a **100× unit mismatch** that propagates through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, inflating the `RETURN_ON_ADVERTISING_SPEND` metric and triggering a column anomaly incident (ongoing since Oct 2025, 76 failure events).

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns in the `final` CTE, matching the pattern already used in `real_time_orders`.
- **`real_time_orders.sql`**: Added a clarifying comment documenting that amounts are in dollars.<br><br>Created by: `maayan+172@elementary-data.com`