### PR TITLE
Maayan via Elementary: Add upstream data quality tests for cpa_and_roas pipeline

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -76,6 +76,8 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tests:
+          - unique
 
       - name: customer_id
         description: Foreign key to the customers table
@@ -108,6 +110,8 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
+        tests:
+          - elementary.column_anomalies
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:

--- a/jaffle_shop_online/tests/assert_real_time_orders_amount_within_max_product_price.sql
+++ b/jaffle_shop_online/tests/assert_real_time_orders_amount_within_max_product_price.sql
@@ -1,0 +1,5 @@
+-- Validates that the amount in real_time_orders does not exceed
+-- the maximum price found in raw_products.
+select *
+from {{ ref('real_time_orders') }}
+where amount > (select max(price) from {{ ref('raw_products') }})


### PR DESCRIPTION
## Summary\n\nAdds 7 data quality tests across 4 upstream models in the `cpa_and_roas` pipeline to improve coverage on this critical finance asset.\n\n### Changes\n\n**orders (3-level upstream)**\n- `unique` on `order_id` — ensures no duplicate orders inflate revenue calculations\n- `elementary.column_anomalies` on `amount` — monitors the amount column that feeds the ROAS calculation\n\n**real_time_orders (4-level upstream)**\n- Singular SQL test validating `amount <= max(price)` from `raw_products` — prevents unrealistic order amounts from the real-time pipeline\n\n**stg_orders (staging)**\n- `elementary.volume_anomalies` — detects row count anomalies at the staging layer\n- `elementary.freshness_anomalies` — detects stale data before it propagates downstream\n\n**stg_payments (staging)**\n- `elementary.volume_anomalies` — detects payment volume anomalies\n- `elementary.freshness_anomalies` — detects stale payment data<br><br>Created by: `maayan+172@elementary-data.com`