### PR TITLE
Maayan via Elementary: fix: convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` outputs them in **dollars** (using the `cents_to_dollars()` macro). Both are UNIONed in the `orders` model, causing a ~100× mismatch in revenue that propagates through:\n\n`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`\n\nThis triggers the **column_anomalies / average** test on `RETURN_ON_ADVERTISING_SPEND`.\n\n## Fix\n\n- **`historical_orders.sql`**: Apply `cents_to_dollars()` to all monetary columns (payment method amounts + total amount)\n- **`real_time_orders.sql`**: Add clarifying comment (no logic change)\n\n## Related\n\n- Incident: column_anomalies average on cpa_and_roas.RETURN_ON_ADVERTISING_SPEND\n- Jira: JSO-1<br><br>Created by: `maayan+172@elementary-data.com`