### PR TITLE
Maayan via Elementary: Add volume & freshness anomaly tests for staging models upstream of cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,13 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
     columns:
       - name: order_id
         tests:
@@ -46,6 +53,13 @@ models:
       owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies:
+          config:
+            severity: warn
+      - elementary.freshness_anomalies:
+          config:
+            severity: warn
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
## Summary\n\nAdds Elementary volume and freshness anomaly tests to two staging models that are upstream dependencies of `cpa_and_roas`:\n\n### `stg_orders`\n- **`elementary.volume_anomalies`** — Detects unexpected row count changes (drops or spikes) that could indicate ingestion failures or data duplication.\n- **`elementary.freshness_anomalies`** — Alerts when the table stops being updated on its expected schedule.\n\n### `stg_payments`\n- **`elementary.volume_anomalies`** — Catches sudden drops (missed payment batches) or spikes (duplicate loads) in row counts.\n- **`elementary.freshness_anomalies`** — Ensures the payments staging table is refreshed on schedule.\n\n## Why\n\nThese staging models feed into the `orders` model, which in turn drives the `cpa_and_roas` financial reporting model. Monitoring volume and freshness at the staging layer provides early detection of pipeline issues before they affect downstream financial calculations.<br><br>Created by: `maayan+172@elementary-data.com`