### PR TITLE
Maayan via Elementary: Add data quality tests for cpa_and_roas upstream models

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -76,6 +76,8 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tests:
+          - unique
 
       - name: customer_id
         description: Foreign key to the customers table
@@ -108,6 +110,10 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
+        tests:
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
@@ -309,7 +315,7 @@ models:
       - name: status
         description: '{{ doc("orders_status") }}'
       - name: amount
-        description: "Total order amount (AUD) – already converted to dollars"
+        description: "Total order amount (AUD) \u2013 already converted to dollars"
       - name: credit_card_amount
         description: "Portion of the order paid with credit card (AUD)"
       - name: coupon_amount

--- a/jaffle_shop_online/tests/assert_rto_amount_bounded_by_max_price.sql
+++ b/jaffle_shop_online/tests/assert_rto_amount_bounded_by_max_price.sql
@@ -1,0 +1,10 @@
+-- Validates that no real-time order amount exceeds the max price from raw_products.
+-- This guards the ROAS calculation in cpa_and_roas from inflated order values.
+
+select
+    order_id,
+    amount
+from {{ ref('real_time_orders') }}
+where amount > (
+    select max(price) from {{ source('products', 'raw_products') }}
+)


### PR DESCRIPTION
## Summary\n\nThis PR adds data quality tests to upstream models that feed the `cpa_and_roas` Return on Advertising Spend calculation.\n\n### Code Changes\n\n**`orders` model (3-level upstream of `cpa_and_roas`)**\n- **`unique` on `order_id`** — The `orders` model unions `historical_orders` and `real_time_orders`. Without a uniqueness test, duplicate orders could silently inflate revenue and corrupt the ROAS metric.\n- **`column_anomalies` (average) on `amount`** — The `amount` column feeds directly into the `attribution_revenue` calculation used by `return_on_advertising_spend`. An anomaly detector catches unexpected shifts before they corrupt ROAS.\n\n**`real_time_orders` model (4-level upstream of `cpa_and_roas`)**\n- **Singular SQL test: `assert_rto_amount_bounded_by_max_price`** — Validates that no real-time order `amount` exceeds the maximum product price from `raw_products`, guarding against inflated order values from the real-time pipeline.\n\n### Cloud monitors (created separately in Elementary)\n- ✅ Volume anomaly on `stg_orders`\n- ✅ Freshness anomaly on `stg_orders`\n- ✅ Volume anomaly on `stg_payments`\n- ✅ Freshness anomaly on `stg_payments`<br><br>Created by: `maayan+172@elementary-data.com`