### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders monetary amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` outputs them in **dollars** (using the `cents_to_dollars` macro). Both models are `UNION ALL`'d in the `orders` model under the same `amount` column.

This unit mismatch causes historical order amounts to be **~100× larger** than real-time amounts, inflating `attribution_revenue` all the way up to `cpa_and_roas.return_on_advertising_spend` — triggering a persistent column anomaly incident (78 failures since Oct 2025).

## Fix

- **`historical_orders.sql`** — Apply `{{ cents_to_dollars() }}` to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`), matching `real_time_orders.sql`.
- **`real_time_orders.sql`** — Add a clarifying comment that amounts are in dollars (no logic change).

## Impact

Resolves the ongoing HIGH severity ROAS anomaly incident on the **cpa_and_roas** model (incident `2924da99`).<br><br>Created by: `maayan+172@elementary-data.com`