### PR TITLE
Maayan via Elementary: Add upstream anomaly tests for cpa_and_roas pipeline

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
## Summary\n\nAdds volume and freshness anomaly monitoring tests to the staging models that feed the `cpa_and_roas` pipeline.\n\n### Changes\n\n**`stg_orders`** (5-level upstream of `cpa_and_roas`):\n- `elementary.volume_anomalies` — detects unexpected row count changes in the orders staging layer\n- `elementary.freshness_anomalies` — detects if order data stops being updated on schedule\n\n**`stg_payments`** (5-level upstream of `cpa_and_roas`):\n- `elementary.volume_anomalies` — detects unexpected row count changes in the payments staging layer\n- `elementary.freshness_anomalies` — detects if payment data stops being updated on schedule\n\n### Why\n\nThese staging models are foundational inputs to the `orders` → `customer_conversions` → `cpa_and_roas` pipeline. Catching volume drops or freshness delays at the staging layer prevents stale or incorrect CPA and ROAS calculations from reaching downstream consumers.<br><br>Created by: `maayan+172@elementary-data.com`