### PR TITLE
Maayan via Elementary: Optimize agg_sessions: explicit columns & incremental filter

### DIFF
--- a/jaffle_shop_online/models/marketing/agg_sessions.sql
+++ b/jaffle_shop_online/models/marketing/agg_sessions.sql
@@ -6,13 +6,31 @@
 }}
 
 with app_sessions as (
-    select *
+    select
+        session_id,
+        customer_id,
+        ad_id,
+        utm_source,
+        started_at,
+        ended_at
     from {{ source("sessions", "stg_app_sessions") }}
+    {% if is_incremental() %}
+        where started_at > (select max(started_at) from {{ this }})
+    {% endif %}
 ),
 
 website_sessions as (
-    select *
+    select
+        session_id,
+        customer_id,
+        ad_id,
+        utm_source,
+        started_at,
+        ended_at
     from {{ source("sessions", "stg_website_sessions") }}
+    {% if is_incremental() %}
+        where started_at > (select max(started_at) from {{ this }})
+    {% endif %}
 )
 
 select *, 'app' as platform


### PR DESCRIPTION
## Performance Optimizations for `agg_sessions`\n\n### Changes\n1. **Replaced `SELECT *` with explicit column selection** — Only selects the 6 columns actually used by the model (`session_id`, `customer_id`, `ad_id`, `utm_source`, `started_at`, `ended_at`), reducing data scanned and protecting against upstream schema changes.\n\n2. **Added `is_incremental()` filter** — Filters both source tables on `started_at > max(started_at)` during incremental runs, so only new rows are processed instead of full table scans. The last full run took ~175 seconds, and this should significantly reduce execution time on incremental runs.\n\n### Impact\n- Reduced compute cost and execution time on incremental runs\n- Lower data warehouse resource consumption\n- More resilient to upstream schema changes<br><br>Created by: `maayan+172@elementary-data.com`