### PR TITLE
Maayan via Elementary: Add upstream data quality tests for cpa_and_roas pipeline

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
## Summary\n\nAdds volume and freshness anomaly monitoring to key staging models in the `cpa_and_roas` upstream lineage.\n\n## Changes\n\n### `stg_orders`\n- **Volume anomaly** — catches unexpected row count changes at the earliest stage of the orders pipeline\n- **Freshness anomaly** — ensures order data is arriving on schedule before it flows into downstream financial models\n\n### `stg_payments`\n- **Volume anomaly** — detects ingestion issues in payment data that would silently corrupt order amounts and ROAS\n- **Freshness anomaly** — ensures payment data freshness so downstream financial metrics stay current\n\n## Context\n\nThese staging models are 5 levels upstream of the critical `cpa_and_roas` model. Without monitoring at this layer, pipeline failures or data delays would propagate undetected through `orders` → `customer_conversions` → `cpa_and_roas`, corrupting cost-per-acquisition and return-on-ad-spend calculations.<br><br>Created by: `maayan+172@elementary-data.com`