### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' + payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\n\nThe `historical_orders` model outputs monetary amounts in **cents** while `real_time_orders` already converts them to **dollars** using the `cents_to_dollars()` macro. Since the `orders` model does a `UNION ALL` of both, this creates a ~100× unit mismatch that propagates through `customer_conversions` → `attribution_touches` → `cpa_and_roas`, causing the ROAS anomaly test to fail.\n\n## Fix\n\n- **`historical_orders.sql`**: Apply the `cents_to_dollars()` macro to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`) to match `real_time_orders`.\n- **`real_time_orders.sql`**: Add a clarifying comment that amounts are already in dollars.\n\n## Impact\n\nResolves the ongoing HIGH severity column anomaly incident on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` (incident running since Oct 22, 2025 with 80+ failure events)."<br><br>Created by: `maayan+172@elementary-data.com`