### PR TITLE
Maayan via Elementary: Add upstream tests for cpa_and_roas pipeline

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -76,6 +76,8 @@ models:
     columns:
       - name: order_id
         description: This is a unique identifier for an order
+        tests:
+          - unique
 
       - name: customer_id
         description: Foreign key to the customers table
@@ -108,6 +110,10 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
+        tests:
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card

--- a/jaffle_shop_online/tests/assert_real_time_orders_amount_within_max_product_price.sql
+++ b/jaffle_shop_online/tests/assert_real_time_orders_amount_within_max_product_price.sql
@@ -1,0 +1,7 @@
+-- Validates that the amount field in real_time_orders
+-- does not exceed the maximum price from raw_products.
+select
+    order_id,
+    amount
+from {{ ref('real_time_orders') }}
+where amount > (select max(price) from {{ source('products', 'raw_products') }})


### PR DESCRIPTION
## Add upstream tests for `cpa_and_roas` pipeline\n\nThis PR adds data quality tests to upstream models that feed the `cpa_and_roas` marketing metrics:\n\n### `orders` model (3-level upstream)\n- **`unique`** on `order_id` — prevents duplicate records from inflating revenue calculations in the ROAS metric\n- **`column_anomalies`** on `amount` (average) — detects anomalies in order amounts that feed the `return_on_advertising_spend` calculation\n\n### Additional cloud tests created\n- **Volume anomaly** and **Freshness anomaly** on `stg_orders` and `stg_payments` (created as Elementary automated monitors)<br><br>Created by: `maayan+172@elementary-data.com`