### PR TITLE
Maayan via Elementary: Add amount validation test for real_time_orders

### DIFF
--- a/jaffle_shop_online/tests/assert_real_time_orders_amount_within_max_product_price.sql
+++ b/jaffle_shop_online/tests/assert_real_time_orders_amount_within_max_product_price.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        meta={'description': 'Validates that the amount field in real_time_orders does not exceed the maximum price from raw_products'},
+        tags=['finance', 'real_time', 'sales'],
+        severity='error'
+    )
+}}
+
+select
+    order_id,
+    amount
+from {{ ref('real_time_orders') }}
+where amount > (select max(price) from {{ ref('raw_products') }})


### PR DESCRIPTION
## Add amount validation test for `real_time_orders`\n\nAdds a singular SQL test that validates the `amount` field in `real_time_orders` does not exceed the maximum price from `raw_products`. This prevents unrealistic order totals from the real-time pipeline from flowing into downstream revenue calculations in `cpa_and_roas`.<br><br>Created by: `maayan+172@elementary-data.com`