### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem

The `historical_orders` model was outputting monetary amounts in **cents** while `real_time_orders` already converts to **dollars** using the `cents_to_dollars` macro. Since the `orders` model unions both with `UNION ALL`, the resulting `amount` column contained mixed units — causing a **100x inflation** in revenue that propagated through:\n\n`orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`\n\nThis triggered the **column_anomalies (average)** test on `RETURN_ON_ADVERTISING_SPEND` (incident HIGH severity, 84+ failure events since Oct 2025).\n\n## Fix\n\n- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns (`amount`, `credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`)\n- **`real_time_orders.sql`**: Added clarifying comment (no logic change)\n\n## Impact\n\nFixes the ROAS anomaly incident on `cpa_and_roas` and restores correct dollar-denominated values across all downstream finance and marketing models.<br><br>Created by: `maayan+172@elementary-data.com`