### PR TITLE
Maayan via Elementary: Add volume and freshness anomaly tests for stg_orders and stg_payments

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -34,13 +34,14 @@ models:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_payments
     meta:
       owner: "@finance-team"
@@ -59,6 +60,9 @@ models:
                 severity: warn
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
 
+    data_tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
   - name: stg_signups
     meta:
       owner: "@customer-team"


### PR DESCRIPTION
Adds upstream data quality tests to catch ROAS anomalies earlier in the pipeline.\n\n## Context\nThe `cpa_and_roas` model has a HIGH severity ROAS column anomaly incident (ongoing since Oct 2025, 84 failure events). These tests add early-warning monitors at the staging layer — 5 hops upstream from `cpa_and_roas`.\n\n## Changes\n- **stg_orders**: Volume anomaly + Freshness anomaly\n- **stg_payments**: Volume anomaly + Freshness anomaly\n\nBoth staging models feed into `real_time_orders` → `orders` → `customer_conversions` → `cpa_and_roas`, so catching issues here provides the earliest possible detection before data quality problems propagate to the ROAS metric and downstream LTV dashboards.<br><br>Created by: `maayan+172@elementary-data.com`