### PR TITLE
Maayan via Elementary: Fix: Convert historical_orders amounts from cents to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -37,7 +37,15 @@ final as (
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {% for payment_method in payment_methods -%}
+    {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
+    {% endfor -%}
+    {{ cents_to_dollars('amount') }} as amount
 from final
 where date(order_date) < (
     select date(max(order_date))

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Problem\n\nThe `historical_orders` model outputs monetary amounts in **cents**, while `real_time_orders` already converts to **dollars** using the `cents_to_dollars()` macro. When `orders` unions these two models, the mixed units cause a ~100× mismatch that propagates through:\n\n`historical_orders` → `orders` → `customer_conversions` → `attribution_touches` → `cpa_and_roas`\n\nThis inflates `RETURN_ON_ADVERTISING_SPEND` and triggers the column anomaly test (incident ongoing since Oct 2025, 84 failure events).\n\n## Fix\n\n- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary columns, matching `real_time_orders`.\n- **`real_time_orders.sql`**: Add clarifying comment about dollar units (no logic change).\n\n## Impact\n\nResolves the ROAS anomaly in `cpa_and_roas` and corrects all downstream metrics that depend on order amounts from historical data.<br><br>Created by: `maayan+172@elementary-data.com`