### PR TITLE
Ella via Elementary: cpa_and_roas: add CPA/ROAS math consistency test

### DIFF
--- a/jaffle_shop_online/tests/assert_cpa_roas_math_consistency.sql
+++ b/jaffle_shop_online/tests/assert_cpa_roas_math_consistency.sql
@@ -1,0 +1,26 @@
+{{
+    config(
+        severity='error',
+        meta={'description': 'Validates that cost_per_acquisition and return_on_advertising_spend stored in cpa_and_roas match their derived formulas (total_spend / attribution_points and attribution_revenue / total_spend) within a 0.01 tolerance.'},
+        tags=['business-rule']
+    )
+}}
+
+select
+    day,
+    utm_source,
+    cost_per_acquisition,
+    return_on_advertising_spend,
+    total_spend,
+    attribution_points,
+    attribution_revenue
+from {{ ref('cpa_and_roas') }}
+where
+    (
+        attribution_points > 0
+        and abs(cost_per_acquisition - (total_spend / attribution_points)) > 0.01
+    )
+    or (
+        total_spend > 0
+        and abs(return_on_advertising_spend - (attribution_revenue / total_spend)) > 0.01
+    )


### PR DESCRIPTION
## Summary

Adds a singular dbt test `assert_cpa_roas_math_consistency` on the `cpa_and_roas` model to validate that stored `cost_per_acquisition` and `return_on_advertising_spend` values match their derived formulas within a 0.01 tolerance.

## Details

- **Test type:** Singular SQL test
- **Severity:** `error`
- **Tags:** `business-rule`
- **Dimension:** Accuracy / Consistency

## Logic

- Fails when `attribution_points > 0` and `|cost_per_acquisition - (total_spend / attribution_points)| > 0.01`
- Fails when `total_spend > 0` and `|return_on_advertising_spend - (attribution_revenue / total_spend)| > 0.01`

---

_🤖 This PR was opened by the Elementary AI agent._<br><br>Created by: `ella+demo@elementary-data.com`