### PR TITLE
Ella via Elementary: Add ROAS validation singular test for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/tests/assert_roas_calculation_cpa_and_roas.sql
+++ b/jaffle_shop_online/tests/assert_roas_calculation_cpa_and_roas.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        tags=['marketing', 'finance', 'data_quality'],
+        meta={'description': 'Verifies that the return_on_advertising_spend column equals attribution_revenue / total_spend for rows where both values are greater than 0. Limited to the last 24 hours.'},
+        severity='warn'
+    )
+}}
+
+-- Validates that ROAS = attribution_revenue / total_spend when both > 0
+select
+    day,
+    utm_source,
+    total_spend,
+    attribution_revenue,
+    return_on_advertising_spend,
+    (1.0 * attribution_revenue / total_spend) as expected_roas
+from {{ ref('cpa_and_roas') }}
+where total_spend > 0
+  and attribution_revenue > 0
+  and day >= dateadd('hour', -24, current_timestamp)
+  and abs(return_on_advertising_spend - (1.0 * attribution_revenue / total_spend)) > 0.0001


### PR DESCRIPTION
## Summary

Adds a singular SQL test that verifies the `return_on_advertising_spend` column in `cpa_and_roas` correctly equals `attribution_revenue / total_spend` for rows where both values are greater than 0.

## Details

- **Type**: Custom singular SQL test
- **Severity**: warn
- **Scope**: Last 24 hours (filtered on `day`)
- **Tolerance**: 0.0001 (to account for floating-point precision)

## Failure Condition

The test returns rows where the stored `return_on_advertising_spend` deviates from the expected `attribution_revenue / total_spend` calculation by more than the tolerance.<br><br>Created by: `ella+demo@elementary-data.com`