### PR TITLE
Ella via Elementary: Propagate column descriptions from stg_orders lineage

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -16,13 +16,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -33,8 +33,8 @@ models:
         description: "The USD amount of money spent"
 
   - name: attribution_touches
-    description: "This is a table that contains all the touch points, by session,
-      with the utm_source, utm_medium and utm_campaign"
+    description: "This is a table that contains all the touch points, by session, with the utm_source,
+      utm_medium and utm_campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -60,13 +60,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -120,9 +120,11 @@ models:
         data_type: number
         description: ""
 
+      - name: order_id
+        description: Unique identifier of the order
   - name: cpa_and_roas
-    description: "This table contains the cost per acquisition and return on ad spend,
-      by source, and per day"
+    description: "This table contains the cost per acquisition and return on ad spend, by source, and
+      per day"
     meta:
       owner: "@finance-team"
     config:
@@ -138,8 +140,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: attribution_points
         data_type: number
@@ -159,8 +161,7 @@ models:
 
       - name: return_on_advertising_spend
         data_type: number
-        description: "The ROI of the ad spend, calculated as attribution_revenue /
-          total_spend"
+        description: "The ROI of the ad spend, calculated as attribution_revenue / total_spend"
         data_tests:
           - elementary.column_anomalies:
               anomaly_direction: both
@@ -179,8 +180,7 @@ models:
                 count: 1
 
   - name: marketing_ads
-    description: "This table contains information on the ad spend, by source, medium
-      and campaign"
+    description: "This table contains information on the ad spend, by source, medium and campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -198,8 +198,8 @@ models:
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -211,8 +211,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
@@ -241,8 +241,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: ad_id
         data_type: varchar
@@ -250,8 +250,8 @@ models:
 
       - name: platform
         data_type: varchar
-        description: "Platform where the session was made. For example, website, iOS
-          app, Android app, etc."
+        description: "Platform where the session was made. For example, website, iOS app, Android app,
+          etc."
 
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
@@ -274,9 +274,11 @@ models:
         data_type: number
         description: "Total revenue amount (USD) of the conversion"
 
+      - name: order_id
+        description: Unique identifier of the order
   - name: sessions
-    description: "This table contains information on the sessions of all the customers
-      and the utm_source, utm_medium and utm_campaign of the session"
+    description: "This table contains information on the sessions of all the customers and the utm_source,
+      utm_medium and utm_campaign of the session"
     meta:
       owner: "@marketing-team"
     config:
@@ -302,13 +304,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar

--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -2,8 +2,8 @@ version: 2
 
 models:
   - name: customers
-    description: This table has basic information about a customer, as well as some
-      derived facts based on a customer's orders
+    description: This table has basic information about a customer, as well as some derived
+      facts based on a customer's orders
     meta:
       owner: "@customer-team"
     config:
@@ -57,8 +57,8 @@ models:
         description: Date (UTC) of a customer's signup to the online shop.
 
   - name: orders
-    description: This table has basic information about orders, as well as some derived
-      facts based on payments
+    description: This table has basic information about orders, as well as some derived facts
+      based on payments
     meta:
       owner: "@sales-team"
     config:
@@ -244,15 +244,15 @@ models:
         description: Amount of the order (AUD) paid for by gift card
 
   - name: order_items
-    description: "Junction table between orders and products, containing the individual
-      line items per order."
+    description: "Junction table between orders and products, containing the individual line
+      items per order."
     meta:
       owner: "@sales-team"
     config:
       tags: ["sales"]
     columns:
       - name: order_id
-        description: "Unique identifier for an order"
+        description: Unique identifier of the order
       - name: sku
         description: "Unique stock-keeping unit for the item"
       - name: quantity
@@ -260,9 +260,15 @@ models:
       - name: sale_price
         description: "Sale price of a single unit (AUD)"
 
+      - name: customer_id
+        description: Foreign key to the customers table
+      - name: order_date
+        description: Date (UTC) that the order was placed
+      - name: status
+        description: 'Order status. One of: placed, shipped, completed, return_pending, returned'
   - name: historical_orders
-    description: "Orders loaded from the historical batch datasets (prior to the current
-      day). Amount fields are stored in cents."
+    description: "Orders loaded from the historical batch datasets (prior to the current day).
+      Amount fields are stored in cents."
     meta:
       owner: "@finance-team"
     config:
@@ -290,9 +296,8 @@ models:
         description: "Portion of the order paid with gift card (in cents)"
 
   - name: real_time_orders
-    description: "Orders ingested from the real-time pipeline for the current day.
-      Monetary fields have already been converted to dollars via the cents_to_dollars
-      macro."
+    description: "Orders ingested from the real-time pipeline for the current day. Monetary
+      fields have already been converted to dollars via the cents_to_dollars macro."
     meta:
       owner: "@finance-team"
     config:

--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -25,22 +25,27 @@ models:
         timestamp_column: "order_date"
     columns:
       - name: order_id
+        description: Unique identifier of the order
         tests:
           - unique:
               config:
                 severity: warn
       - name: status
+        description: 'Order status. One of: placed, shipped, completed, return_pending,
+          returned'
         tests:
           - accepted_values:
               config:
                 severity: warn
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              values: ["placed", "shipped", "completed", "return_pending", "returned"]
           - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              value_set: ["placed", "shipped", "completed", "return_pending", "returned"]
               quote_values: true
 
+      - name: customer_id
+        description: Foreign key to the customers table
+      - name: order_date
+        description: Date (UTC) that the order was placed
   - name: stg_payments
     meta:
       owner: "@finance-team"


### PR DESCRIPTION
This PR propagates column descriptions through the lineage starting from `stg_orders`.

Descriptions were sourced from existing downstream dbt models (`historical_orders`, `orders`, `lost_orders`) where the same column name already carried an agreed description, then back-filled to `stg_orders` and forward-filled to downstream models that were missing them.

### Changes
- **stg_orders** — added descriptions for `customer_id`, `order_date`, `order_id`, `status`
- **order_items** — added descriptions for `customer_id`, `order_date`, `status` (and aligned `order_id` wording)
- **customer_conversions** — added description for `order_id`
- **attribution_touches** — added description for `order_id`

### Rationale
Consistent column descriptions through the lineage improve data discoverability in the catalog and help downstream consumers understand what each field represents without needing to trace back to source models.<br><br>Created by: `ella+demo@elementary-data.com`