### PR TITLE
Maayan via Elementary: Fix unit mismatch in historical_orders (cents → dollars)

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' ~ payment_method ~ '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Summary

Fixes a **unit mismatch** in the `orders` model that was causing anomalous values in `cpa_and_roas.return_on_advertising_spend`.

## Root Cause

`orders` is a `UNION ALL` of `historical_orders` and `real_time_orders`. The two branches were emitting `amount` in **different units**:

- `real_time_orders.amount` → **dollars** (uses `cents_to_dollars`)
- `historical_orders.amount` → **cents** (no conversion)

This ~100× mismatch propagates into `customer_conversions.revenue` → `attribution_touches.linear_revenue` → `cpa_and_roas.attribution_revenue`, inflating ROAS for historical rows and triggering the `column_anomalies / average` test on `RETURN_ON_ADVERTISING_SPEND`.

## Changes

- `models/historical_orders.sql`: wrap `total_amount` and each payment-method column with the `cents_to_dollars` macro so `amount` is now in dollars, consistent with `real_time_orders`.
- `models/real_time_orders.sql`: add a top-of-file comment documenting the unit convention.

## Related Incident

- Incident: `column_anomalies - Average` on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND`
- Ticket: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`