### PR TITLE
Maayan via Elementary: Add volume & freshness anomaly tests to staging models feeding cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/staging/schema.yml
+++ b/jaffle_shop_online/models/staging/schema.yml
@@ -23,6 +23,9 @@ models:
       tags: ["staging", "finance", "sales"]
       elementary:
         timestamp_column: "order_date"
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: order_id
         tests:
@@ -46,6 +49,9 @@ models:
       owner: "@finance-team"
     config:
       tags: ["staging", "finance"]
+    tests:
+      - elementary.volume_anomalies
+      - elementary.freshness_anomalies
     columns:
       - name: payment_id
         tests:


### PR DESCRIPTION
## Summary

Adds volume and freshness anomaly tests to staging models feeding the `cpa_and_roas` lineage.

### Changes
- `stg_orders`: added `elementary.volume_anomalies` and `elementary.freshness_anomalies`
- `stg_payments`: added `elementary.volume_anomalies` and `elementary.freshness_anomalies`

### Motivation
These staging models sit upstream of the critical `cpa_and_roas` finance model. Volume and freshness monitoring at the staging layer catches ingestion issues early, before they propagate into marketing/finance reporting.

### Notes
- Existing tests and configuration are preserved
- Only `models/staging/schema.yml` is modified<br><br>Created by: `maayan+172@elementary-data.com`