### PR TITLE
Maayan via Elementary: fix: normalise historical_orders amounts to dollars to fix ROAS anomaly

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -29,10 +29,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- convert every monetary field and the total
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' ~ payment_method ~ '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Summary

Fixes a unit mismatch between `historical_orders` and `real_time_orders` that was driving a ROAS anomaly on the `cpa_and_roas` model.

## Root Cause

`real_time_orders` converts `amount_cents` → dollars via the `cents_to_dollars` macro, while `historical_orders` was emitting the raw value (still in **cents**). Because `orders` UNIONs both branches, half of the revenue stream was inflated ~100×, propagating through `customer_conversions → attribution_touches → cpa_and_roas` and triggering the `column_anomalies - average` test on `RETURN_ON_ADVERTISING_SPEND`.

## Changes

- **`models/historical_orders.sql`**: apply `cents_to_dollars` to every monetary field in the `final` CTE so output matches `real_time_orders`.
- **`models/real_time_orders.sql`**: add a top-of-file comment clarifying that monetary amounts are in dollars (prevents future drift).

## Related Incident

- `column_anomalies - Average` failed on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` (owner: @finance-team, JIRA: JSO-1).<br><br>Created by: `maayan+172@elementary-data.com`