### PR TITLE
Maayan via Elementary: fix: align historical_orders units with real_time_orders (cents → dollars)

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -29,10 +29,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- convert every monetary field and the total
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' ~ payment_method ~ '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Summary

Fixes the unit mismatch in the `orders` model that was causing the `column_anomalies - Average` test on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` to fail.

## Root cause

`orders` is a `UNION ALL` of `historical_orders` and `real_time_orders`. The two branches were emitting `amount` in different units:

- **`real_time_orders.amount`** — already converted to dollars via `cents_to_dollars()`
- **`historical_orders.amount`** — emitted as-is in cents (no conversion)

This 100× mismatch propagated through `customer_conversions.revenue` → `attribution_touches.linear_revenue` → `cpa_and_roas.return_on_advertising_spend`, triggering the anomaly test.

## Changes

- **`models/historical_orders.sql`** — apply `cents_to_dollars()` to all monetary fields (`credit_card_amount`, `coupon_amount`, `bank_transfer_amount`, `gift_card_amount`, `total_amount`) so `amount` is now in dollars, matching `real_time_orders`.
- **`models/real_time_orders.sql`** — added a top-of-file comment documenting that all monetary amounts are in dollars.

## Related

- Incident: `2924da99-a790-4dcb-b92a-5f9571d1fdce`
- Ticket: [JSO-1](https://elementary-data-test.atlassian.net/browse/JSO-1)<br><br>Created by: `maayan+172@elementary-data.com`