### PR TITLE
Ella via Elementary: Add singular test: validate ROAS calculation in cpa_and_roas

### DIFF
--- a/jaffle_shop_online/tests/assert_roas_calculation_is_correct.sql
+++ b/jaffle_shop_online/tests/assert_roas_calculation_is_correct.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        severity='error',
+        meta={'description': 'Validates ROAS = (attribution_revenue / total_spend) * 100 when both inputs are > 0.'},
+        tags=['finance', 'data_quality']
+    )
+}}
+
+-- Validates that return_on_advertising_spend equals (attribution_revenue / total_spend) * 100
+-- when both attribution_revenue > 0 and total_spend > 0.
+-- A small tolerance avoids floating-point false positives.
+
+with validation as (
+
+    select
+        day,
+        utm_source,
+        total_spend,
+        attribution_revenue,
+        return_on_advertising_spend as actual_roas,
+        (100.0 * attribution_revenue / total_spend) as expected_roas
+    from {{ ref('cpa_and_roas') }}
+    where total_spend > 0
+      and attribution_revenue > 0
+
+)
+
+select *
+from validation
+where return_on_advertising_spend is null
+   or abs(actual_roas - expected_roas) > 0.0001
+


### PR DESCRIPTION
## Summary

Adds a singular SQL test that validates the **Return on Ad Spend (ROAS)** calculation in `cpa_and_roas`.

## What the test does

When both `attribution_revenue > 0` and `total_spend > 0`, asserts that:

`return_on_advertising_spend ≈ (attribution_revenue / total_spend) * 100`

A tolerance of `0.0001` is used to avoid floating-point false positives. The test also flags rows where ROAS is unexpectedly NULL within the qualifying population.

## Why

- Catches arithmetic regressions in the ROAS column.
- Encodes the actual implementation (percentage form, with the `× 100` factor) so any drift between the formula and the documented business rule is detected immediately.

## Notes

The column description for `return_on_advertising_spend` currently reads "calculated as attribution_revenue / total_spend" but the implementation multiplies by 100. Consider aligning the description in a follow-up.
<br><br>Created by: `ella+demo@elementary-data.com`