### PR TITLE
Maayan via Elementary: Fix unit mismatch in historical_orders (cents → dollars)

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Root Cause

The `cpa_and_roas.return_on_advertising_spend` anomaly test failure was traced upstream to a **unit mismatch** in the `orders` model:

- `real_time_orders.amount` is converted from cents to dollars
- `historical_orders.amount` was left in **cents** (no conversion)

These two branches are unioned together in `orders`, producing a 100× scale discrepancy that propagates downstream into revenue and ROAS metrics.

## Fix

- **`historical_orders.sql`**: Apply `cents_to_dollars()` macro to all monetary fields, matching `real_time_orders`
- **`real_time_orders.sql`**: Add a clarifying comment that amounts are in dollars

## Related Incident

[Incident 706daf9d](https://app.elementary-data.com/incidents/706daf9d-1454-496b-b06a-80e7ae036d76) — `column_anomalies` failing on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` (last avg `0.205` vs expected `~70.49`).<br><br>Created by: `maayan+172@elementary-data.com`