### PR TITLE
Mika via Elementary: Fix ROAS unit mismatch — convert historical_orders amounts cents→dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -29,10 +29,11 @@ final as (
         o.customer_id,
         o.order_date,
         o.status,
+        -- convert every monetary field and the total
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars(payment_method + '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Root Cause

The `cpa_and_roas.return_on_advertising_spend` metric collapsed from a training average of ~51.46 to ~0.15 (≈100× drop), triggering a column anomaly incident.

Walking the lineage upstream from `cpa_and_roas` revealed that `orders` UNIONs two branches with **inconsistent units** for `amount`:

- `historical_orders.amount` — passed through unscaled (treated as dollars)
- `real_time_orders.amount` — divided by 100 via `cents_to_dollars` (treated as cents at source, dollars after conversion)

As the rolling window shifted toward recent orders, the `real_time_orders` branch increasingly dominated the aggregation, producing a ~100× downscale in attributed revenue and therefore in ROAS.

## Fix

- **`historical_orders.sql`**: apply `cents_to_dollars` to `total_amount` and each per-payment-method amount, matching `real_time_orders` semantics.
- **`real_time_orders.sql`**: add a top-of-file comment documenting that all monetary amounts are in dollars.

## Follow-up

Consider adding a `scale_consistency` test comparing the average `amount` across the two branches to catch future regressions.<br><br>Created by: `mika+demo@elementary-data.com`