### PR TITLE
Maayan via Elementary: Fix ROAS anomaly: normalize historical_orders amounts to dollars

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -30,9 +30,9 @@ final as (
         o.order_date,
         o.status,
         {% for payment_method in payment_methods -%}
-        op.{{ payment_method }}_amount,
+        {{ cents_to_dollars('op.' ~ payment_method ~ '_amount') }} as {{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        {{ cents_to_dollars('op.total_amount') }} as amount  -- Amount is now in dollars
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )

--- a/jaffle_shop_online/models/real_time_orders.sql
+++ b/jaffle_shop_online/models/real_time_orders.sql
@@ -1,3 +1,4 @@
+-- All monetary amounts in this model are in dollars
 {{
   config(materialized='view')
 }}


### PR DESCRIPTION
## Root Cause

The `column_anomalies` test on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` was failing because `historical_orders.amount` was emitted in **cents** while `real_time_orders.amount` was already converted to **dollars**. The `orders` model UNIONs both, polluting `customer_conversions.revenue` and `attribution_touches.linear_revenue`, which collapsed the ROAS metric ~100×.

## Fix

- `models/historical_orders.sql`: apply the existing `cents_to_dollars` macro to all monetary columns so its output matches `real_time_orders`.
- `models/real_time_orders.sql`: add a header comment clarifying the unit (no logic change).

## Verification

After merge, the next run of `cpa_and_roas` should restore the ROAS average to its expected ~51 range and clear the open incident.<br><br>Created by: `maayan+172@elementary-data.com`