### PR TITLE
Ella via Elementary: Add custom SQL test validating ROAS calculation in cpa_and_roas

### DIFF
--- a/jaffle_shop_online/tests/assert_cpa_and_roas_roas_calculation.sql
+++ b/jaffle_shop_online/tests/assert_cpa_and_roas_roas_calculation.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        severity='error',
+        tags=['finance', 'data_quality'],
+        meta={'description': 'Validates ROAS = 100 * attribution_revenue / total_spend (matches model logic) when both values are positive. Partitioned on day for efficiency, scoped to last 24 hours.'}
+    )
+}}
+
+{{ config(severity = 'error') }}
+
+select
+    day,
+    utm_source,
+    attribution_revenue,
+    total_spend,
+    return_on_advertising_spend,
+    (100.0 * attribution_revenue / total_spend) as expected_roas
+from {{ ref('cpa_and_roas') }}
+where day >= dateadd(hour, -24, current_timestamp)
+  and attribution_revenue > 0
+  and total_spend > 0
+  and abs(return_on_advertising_spend - (100.0 * attribution_revenue / total_spend)) > 0.0001


### PR DESCRIPTION
## Summary

Adds a custom SQL test (`assert_cpa_and_roas_roas_calculation`) to validate the ROAS calculation in the `cpa_and_roas` model.

## What it checks

For every row where `attribution_revenue > 0` and `total_spend > 0`, verifies that `return_on_advertising_spend` equals `100.0 * attribution_revenue / total_spend` (matching the model's actual SQL).

## Implementation notes

- **Partitioned on `day`** for efficient query execution.
- **Limited to last 24 hours** (`day >= dateadd(hour, -24, current_timestamp)`).
- Uses an epsilon (`0.0001`) tolerance to avoid floating-point false positives.
- Severity: `error`.<br><br>Created by: `ella+demo@elementary-data.com`