### PR TITLE
Maayan via Elementary: Add data quality tests to cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -16,13 +16,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -33,8 +33,8 @@ models:
         description: "The USD amount of money spent"
 
   - name: attribution_touches
-    description: "This is a table that contains all the touch points, by session,
-      with the utm_source, utm_medium and utm_campaign"
+    description: "This is a table that contains all the touch points, by session, with the utm_source,
+      utm_medium and utm_campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -60,13 +60,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -121,8 +121,8 @@ models:
         description: ""
 
   - name: cpa_and_roas
-    description: "This table contains the cost per acquisition and return on ad spend,
-      by source, and per day"
+    description: "This table contains the cost per acquisition and return on ad spend, by source, and
+      per day"
     meta:
       owner: "@finance-team"
     config:
@@ -136,11 +136,19 @@ models:
         data_type: date
         description: "Day (UTC)"
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: day
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
+        data_tests:
+          - not_null:
+              arguments:
+                column_name: utm_source
       - name: attribution_points
         data_type: number
         description: "Total number of attribution points"
@@ -159,8 +167,7 @@ models:
 
       - name: return_on_advertising_spend
         data_type: number
-        description: "The ROI of the ad spend, calculated as attribution_revenue /
-          total_spend"
+        description: "The ROI of the ad spend, calculated as attribution_revenue / total_spend"
         data_tests:
           - elementary.column_anomalies:
               anomaly_direction: both
@@ -178,9 +185,39 @@ models:
                 period: day
                 count: 1
 
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - day
+              - utm_source
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: total_spend >= 0
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: attribution_points >= 0
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: attribution_revenue >= 0
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: abs(cost_per_acquisition - (total_spend * 1.0 / attribution_points)) < 0.01
+          config:
+            where: total_spend > 0 and attribution_points > 0
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: abs(return_on_advertising_spend - (100.0 * attribution_revenue / total_spend))
+              < 0.01
+          config:
+            where: total_spend > 0 and attribution_revenue > 0
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: cost_per_acquisition is null
+          config:
+            where: total_spend = 0 or attribution_points = 0
   - name: marketing_ads
-    description: "This table contains information on the ad spend, by source, medium
-      and campaign"
+    description: "This table contains information on the ad spend, by source, medium and campaign"
     meta:
       owner: "@marketing-team"
     config:
@@ -198,8 +235,8 @@ models:
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar
@@ -211,8 +248,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
   - name: agg_sessions
     description: "This table contains aggregated information on the sessions"
@@ -241,8 +278,8 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: ad_id
         data_type: varchar
@@ -250,8 +287,8 @@ models:
 
       - name: platform
         data_type: varchar
-        description: "Platform where the session was made. For example, website, iOS
-          app, Android app, etc."
+        description: "Platform where the session was made. For example, website, iOS app, Android app,
+          etc."
 
   - name: customer_conversions
     description: "This table contains information on the conversions of all the customers"
@@ -275,8 +312,8 @@ models:
         description: "Total revenue amount (USD) of the conversion"
 
   - name: sessions
-    description: "This table contains information on the sessions of all the customers
-      and the utm_source, utm_medium and utm_campaign of the session"
+    description: "This table contains information on the sessions of all the customers and the utm_source,
+      utm_medium and utm_campaign of the session"
     meta:
       owner: "@marketing-team"
     config:
@@ -302,13 +339,13 @@ models:
 
       - name: utm_source
         data_type: varchar
-        description: "Source where the ad was displayed. For example, Google, Facebook,
-          Twitter, Newsletter, etc."
+        description: "Source where the ad was displayed. For example, Google, Facebook, Twitter, Newsletter,
+          etc."
 
       - name: utm_medium
         data_type: varchar
-        description: "The advertising or marketing medium. The medium can be social
-          media, banners, CPC, third-party blogs, etc."
+        description: "The advertising or marketing medium. The medium can be social media, banners,
+          CPC, third-party blogs, etc."
 
       - name: utm_campain
         data_type: varchar


### PR DESCRIPTION
Adds four high-impact generic dbt tests to `cpa_and_roas`:

- **Uniqueness** on the `(day, utm_source)` grain via `dbt_utils.unique_combination_of_columns`
- **`not_null`** on `day` and `utm_source`
- **Non-negativity** on `total_spend`, `attribution_points`, `attribution_revenue`
- **Internal consistency** of `cost_per_acquisition` and `return_on_advertising_spend` against their formulas, plus a guard that CPA is null when inputs don't qualify

These complement the existing freshness, volume, and column-anomaly cloud tests by covering grain integrity, validity, and business-logic accuracy — directly relevant to the open ROAS column-anomaly failure.<br><br>Created by: `maayan+172@elementary-data.com`