### PR TITLE
Maayan via Elementary: fix(orders): convert historical_orders amounts to dollars to fix ROAS unit mismatch

### DIFF
--- a/jaffle_shop_online/models/historical_orders.sql
+++ b/jaffle_shop_online/models/historical_orders.sql
@@ -32,12 +32,21 @@ final as (
         {% for payment_method in payment_methods -%}
         op.{{ payment_method }}_amount,
         {% endfor -%}
-        op.total_amount    as amount
+        op.total_amount    as amount_cents
     from orders o
     left join order_payments op on o.order_id = op.order_id
 )
 
-select *
+select
+    order_id,
+    customer_id,
+    order_date,
+    status,
+    {{ cents_to_dollars('amount_cents') }} as amount,
+    {{ cents_to_dollars('bank_transfer_amount') }} as bank_transfer_amount,
+    {{ cents_to_dollars('coupon_amount') }} as coupon_amount,
+    {{ cents_to_dollars('credit_card_amount') }} as credit_card_amount,
+    {{ cents_to_dollars('gift_card_amount') }} as gift_card_amount
 from final
 where date(order_date) < (
     select date(max(order_date))


### PR DESCRIPTION
## Root cause

The cloud anomaly test on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` has been failing since 2026-04-30 (recent average **0.03–0.84** vs trained baseline **~58**, ~100× drop).

`models/orders.sql` `UNION ALL`s two upstream models that emit the `amount` column in **different units**:

- `models/historical_orders.sql` → `op.total_amount as amount` (cents, raw from `stg_payments`)
- `models/real_time_orders.sql` → `cents_to_dollars(amount_cents) as amount` (dollars)

The mixed-unit `amount` flows through `customer_conversions.revenue` → `attribution_touches.linear_revenue` → `cpa_and_roas.attribution_revenue`. As real-time orders (dollars) overtake historical (cents) in recent days, the numerator of `attribution_revenue / total_spend` collapses ~100×.

## Fix

Apply `cents_to_dollars` to all monetary columns in `historical_orders.sql` so both branches of `orders` emit values in dollars, matching `real_time_orders` and the `stg_payments`-as-cents convention.

## Follow-up

After merge, the anomaly test on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` will need a baseline reset — the historical "average ~58" was itself an artifact of the unit bug; true dollar ROAS is ~0.5.

Related incident: `706daf9d-1454-496b-b06a-80e7ae036d76`<br><br>Created by: `maayan+172@elementary-data.com`