### PR TITLE
Maayan via Elementary: fix(marketing_ads): explicit column lists to prevent silent column shift in union all

### DIFF
--- a/jaffle_shop_online/models/marketing/marketing_ads.sql
+++ b/jaffle_shop_online/models/marketing/marketing_ads.sql
@@ -6,25 +6,40 @@
 }}
 
 with google_ads as (
-    select *
+    select
+        ad_id,
+        date,
+        utm_medium,
+        utm_campain,
+        cost,
+        'google' as utm_source
     from {{ source("ads", "stg_google_ads") }}
 ),
 
 facebook_ads as (
-    select *
+    select
+        ad_id,
+        date,
+        utm_medium,
+        utm_campain,
+        cost,
+        'facebook' as utm_source
     from {{ source("ads", "stg_facebook_ads") }}
 ),
 
 instagram_ads as (
-    select *
+    select
+        ad_id,
+        date,
+        utm_medium,
+        utm_campain,
+        cost,
+        'instagram' as utm_source
     from {{ source("ads", "stg_instagram_ads") }}
 )
 
-select *, 'google' as utm_source
-from google_ads
+select * from google_ads
 union all
-select *, 'facebook' as utm_source
-from facebook_ads
+select * from facebook_ads
 union all
-select *, 'instagram' as utm_source
-from instagram_ads
+select * from instagram_ads


### PR DESCRIPTION
## Context

Incident `706daf9d-1454-496b-b06a-80e7ae036d76`: the column anomaly test on
`cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` is failing — daily ROAS dropped
from ~57.9 to 0.034 (~1,700x).

Root-causing upstream pointed to `marketing_ads`, which combined the three
ad sources using `select *` + `union all`. `union all` aligns columns by
ordinal position, so any drift in column order in one of `stg_google_ads`,
`stg_facebook_ads`, `stg_instagram_ads` silently shifts values across
columns — e.g. a non-numeric value landing in `cost`, which then explodes
`sum(cost)` in `ads_spend` and crushes ROAS.

## Change

Replace `select *` with explicit column lists in each CTE, and move the
`utm_source` literal inside each CTE so the projected column order is
identical and locked across all three branches of the union.

## Effect

- Column order is now explicit; any future schema drift in a source
  becomes a compilation error rather than silent data corruption.
- No change to the resulting columns or rows under steady-state.

After merge, the next scheduled run of `marketing_ads` → `ads_spend` →
`cpa_and_roas` should restore expected ROAS values.<br><br>Created by: `maayan+172@elementary-data.com`