### PR TITLE
Maayan via Elementary: Test Coverage for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -32,6 +32,102 @@ models:
         data_type: number
         description: "The USD amount of money spent"
 
+  - name: cpa_and_roas
+    description: "This table contains the cost per acquisition and return on ad spend, by source, and per day"
+    meta:
+      owner: "@finance-team"
+    config:
+      tags: ["marketing", "finance", "finance-data-product", "no_pii"]
+      elementary:
+        timestamp_column: "day"
+    data_tests:
+      # Primary key: grain is (day, utm_source)
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - utm_source
+          config:
+            where: "day >= dateadd('day', -1, current_date)"
+            meta:
+              quality_dimension: uniqueness
+    columns:
+      - name: day
+        data_type: date
+        description: "Day (UTC) of the CPA and ROAS metrics"
+        data_tests:
+          - not_null:
+              config:
+                where: "day >= dateadd('day', -1, current_date)"
+                meta:
+                  quality_dimension: completeness
+
+      - name: utm_source
+        data_type: varchar
+        description: "Source where the ad was displayed. For example, Google, Facebook,
+          Twitter, Newsletter, etc."
+        data_tests:
+          - not_null:
+              config:
+                where: "day >= dateadd('day', -1, current_date)"
+                meta:
+                  quality_dimension: completeness
+
+      - name: total_spend
+        data_type: number
+        description: "Total USD amount spent on ads for the day and source"
+        data_tests:
+          - not_null:
+              config:
+                where: "day >= dateadd('day', -1, current_date)"
+                meta:
+                  quality_dimension: completeness
+          - dbt_utils.accepted_range:
+              min_value: 0
+              config:
+                where: "day >= dateadd('day', -1, current_date)"
+                meta:
+                  quality_dimension: validity
+
+      - name: attribution_points
+        data_type: number
+        description: "Total attribution points for the day and source"
+
+      - name: attribution_revenue
+        data_type: number
+        description: "Total attributed revenue (USD) for the day and source"
+
+      - name: cost_per_acquisition
+        data_type: number
+        description: "Cost (USD) per acquisition, calculated as total_spend / attribution_points"
+        data_tests:
+          - not_null:
+              config:
+                where: "day >= dateadd('day', -1, current_date) and total_spend > 0 and attribution_points > 0"
+                meta:
+                  quality_dimension: completeness
+          - dbt_utils.accepted_range:
+              min_value: 0
+              config:
+                where: "day >= dateadd('day', -1, current_date) and cost_per_acquisition is not null"
+                meta:
+                  quality_dimension: accuracy
+
+      - name: return_on_advertising_spend
+        data_type: number
+        description: "The ROI of the ad spend, calculated as attribution_revenue / total_spend"
+        data_tests:
+          - not_null:
+              config:
+                where: "day >= dateadd('day', -1, current_date) and total_spend > 0 and attribution_revenue > 0"
+                meta:
+                  quality_dimension: completeness
+          - dbt_utils.accepted_range:
+              min_value: 0
+              config:
+                where: "day >= dateadd('day', -1, current_date) and return_on_advertising_spend is not null"
+                meta:
+                  quality_dimension: accuracy
+
   - name: attribution_touches
     description: "This is a table that contains all the touch points, by session,
       with the utm_source, utm_medium and utm_campaign"


### PR DESCRIPTION
## Test Coverage for `cpa_and_roas`

Adds structural dbt test coverage to the `cpa_and_roas` marketing model, which previously had **no generic dbt tests** (only Elementary cloud/anomaly monitors).

### Context
- Model: `models/marketing/cpa_and_roas.sql`
- Grain: `(day, utm_source)`
- Owner: `@finance-team` | High usage (5,564 queries / 10 users / 30 days, 71st percentile)

### Tests added (9)
All use **generic / packaged dbt tests** (no custom SQL), each scoped to the **last 24 hours** via `config.where` on the `day` partition, and each carries a **`quality_dimension`**:

| Test | Column(s) | Dimension |
|------|-----------|-----------|
| `dbt_utils.unique_combination_of_columns` (primary key) | `day` + `utm_source` | uniqueness |
| `not_null` | `day` | completeness |
| `not_null` | `utm_source` | completeness |
| `not_null` | `total_spend` | completeness |
| `dbt_utils.accepted_range` (min 0) | `total_spend` | validity |
| `not_null` | `cost_per_acquisition` | completeness |
| `dbt_utils.accepted_range` (min 0) | `cost_per_acquisition` | accuracy |
| `not_null` | `return_on_advertising_spend` | completeness |
| `dbt_utils.accepted_range` (min 0) | `return_on_advertising_spend` | accuracy |

### Notes
- CPA and ROAS are nullable by model design (the `case` expressions return `null` when spend/points/revenue are absent). Their `not_null` tests are scoped to rows where the inputs are populated (`total_spend > 0` etc.), and the range tests guard with `is not null`, to validate populated rows without false positives.
- Added a **`no_pii`** tag to the model (aggregated spend/ROAS by source — no personal data) per governance policy.<br><br>Created by: `maayan+172@elementary-data.com`