### PR TITLE
Maayan via Elementary: Fix ROAS anomaly: normalize Facebook cost units in marketing_ads

### DIFF
--- a/jaffle_shop_online/models/marketing/marketing_ads.sql
+++ b/jaffle_shop_online/models/marketing/marketing_ads.sql
@@ -20,11 +20,14 @@ instagram_ads as (
     from {{ source("ads", "stg_instagram_ads") }}
 )
 
-select *, 'google' as utm_source
+-- Normalize cost to a common currency unit (dollars) before unioning.
+-- Facebook reports cost in cents, while Google and Instagram report in dollars.
+-- Without this conversion, total ad spend is inflated and ROAS collapses.
+select ad_id, date, utm_medium, utm_campain, cost, 'google' as utm_source
 from google_ads
 union all
-select *, 'facebook' as utm_source
+select ad_id, date, utm_medium, utm_campain, cost / 100.0 as cost, 'facebook' as utm_source
 from facebook_ads
 union all
-select *, 'instagram' as utm_source
+select ad_id, date, utm_medium, utm_campain, cost, 'instagram' as utm_source
 from instagram_ads


### PR DESCRIPTION
## Root cause

The `column_anomalies` test fired on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` (HIGH, open since 2026-06-08). The last ROAS value was **0.145** vs a training average of **65.166** (~450x drop).

Code walk upstream:
- `cpa_and_roas` computes ROAS = `attribution_revenue / total_spend`
- `ads_spend` passes through `sum(cost) as spend`
- `marketing_ads` unions `stg_google_ads`, `stg_facebook_ads`, `stg_instagram_ads` with `select *` and **no unit normalization** on `cost`

Facebook reports `cost` in **cents** while Google and Instagram report in **dollars**. The `union all` summed mismatched units, inflating `total_spend` ~100x and collapsing ROAS.

## Fix

Replace `select *` with explicit columns and divide Facebook's `cost` by 100 to convert cents → dollars before the union.<br><br>Created by: `maayan+172@elementary-data.com`