### PR TITLE
yonni via Elementary: Add formula-consistency singular test for cpa_and_roas

### DIFF
--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -131,6 +131,12 @@ models:
         - "finance-data-product"
       elementary:
         timestamp_column: "day"
+    data_tests:
+      - assert_cpa_and_roas_formula_consistency:
+          config:
+            severity: error
+          meta:
+            data_quality_dimension: accuracy
     columns:
       - name: day
         data_type: date

--- a/jaffle_shop_online/tests/assert_cpa_and_roas_formula_consistency.sql
+++ b/jaffle_shop_online/tests/assert_cpa_and_roas_formula_consistency.sql
@@ -1,0 +1,39 @@
+-- Validates that the CPA and ROAS metrics in cpa_and_roas match their
+-- documented formula definitions, and that they are null exactly when the
+-- inputs are not both positive.
+--
+-- Data quality dimension: accuracy
+-- Scoped to the last 24 hours via the `day` partition for efficient,
+-- partition-pruned execution.
+
+with validation as (
+
+    select
+        day,
+        utm_source,
+        total_spend,
+        attribution_points,
+        attribution_revenue,
+        cost_per_acquisition,
+        return_on_advertising_spend
+    from {{ ref('cpa_and_roas') }}
+    where day >= dateadd(day, -1, current_date)
+
+)
+
+select *
+from validation
+where
+    -- CPA must equal total_spend / attribution_points when both are positive
+    ( total_spend > 0 and attribution_points > 0
+      and abs(cost_per_acquisition - (1.0 * total_spend / attribution_points)) > 0.01 )
+
+    -- ROAS must equal 100 * attribution_revenue / total_spend (percentage units)
+    or ( total_spend > 0 and attribution_revenue > 0
+         and abs(return_on_advertising_spend - (100.0 * attribution_revenue / total_spend)) > 0.01 )
+
+    -- CPA must be null when inputs are not both positive
+    or ( not (total_spend > 0 and attribution_points > 0) and cost_per_acquisition is not null )
+
+    -- ROAS must be null when inputs are not both positive
+    or ( not (total_spend > 0 and attribution_revenue > 0) and return_on_advertising_spend is not null )


### PR DESCRIPTION
## What

Adds a singular dbt test `assert_cpa_and_roas_formula_consistency` validating that the CPA and ROAS metrics in `cpa_and_roas` match their documented formula definitions, and are null exactly when the inputs are not both positive.

## Why

`cpa_and_roas` is a finance-data-product (5,409 queries / 10 users over the last 30 days) with only anomaly, freshness, and volume monitors today. None of them validate that the metric **math** is internally consistent. The model computes `return_on_advertising_spend = 100 * attribution_revenue / total_spend` (a percentage), while the column description states `attribution_revenue / total_spend` — exactly the kind of silent unit/formula drift anomaly tests won't reliably catch.

This invariant is a cross-column conditional arithmetic check that no generic dbt test (`dbt_utils`, `dbt_expectations`, native) can express, so a singular SQL test is the correct fit.

## Details

- **Data quality dimension:** `accuracy` (declared via `meta`)
- **Severity:** `error`
- **Scope:** last 24 hours via the `day` partition (`day >= dateadd(day, -1, current_date)`) for partition-pruned execution, consistent with the model's `timestamp_column: day`
- Declared under the model using the repo's `data_tests:` convention<br><br>Created by: `yonni+dema@elementary-data.com`