### PR TITLE
Maayan via Elementary: Fix ROAS anomaly: make ad-spend cost units explicit in marketing_ads

### DIFF
--- a/jaffle_shop_online/models/marketing/marketing_ads.sql
+++ b/jaffle_shop_online/models/marketing/marketing_ads.sql
@@ -5,26 +5,54 @@
     )
 }}
 
+-- NOTE: `cost` from every ad platform MUST be expressed in USD (dollars)
+-- before it is unioned here. Downstream `ads_spend.spend` and the ROAS /
+-- CPA metrics in `cpa_and_roas` assume a single, consistent unit. If a
+-- platform's feed starts reporting cost in a different unit (e.g. cents),
+-- convert it to dollars in that source's CTE below. This `unit_divisor`
+-- pattern keeps the conversion explicit and per-source so a future unit
+-- mismatch is visible and correctable in one place.
+{% set cost_unit_divisor = {
+    "google": 1,
+    "facebook": 1,
+    "instagram": 1,
+} %}
+
 with google_ads as (
-    select *
+    select
+        ad_id,
+        date,
+        utm_medium,
+        utm_campain,
+        cost / {{ cost_unit_divisor["google"] }} as cost,
+        'google' as utm_source
     from {{ source("ads", "stg_google_ads") }}
 ),
 
 facebook_ads as (
-    select *
+    select
+        ad_id,
+        date,
+        utm_medium,
+        utm_campain,
+        cost / {{ cost_unit_divisor["facebook"] }} as cost,
+        'facebook' as utm_source
     from {{ source("ads", "stg_facebook_ads") }}
 ),
 
 instagram_ads as (
-    select *
+    select
+        ad_id,
+        date,
+        utm_medium,
+        utm_campain,
+        cost / {{ cost_unit_divisor["instagram"] }} as cost,
+        'instagram' as utm_source
     from {{ source("ads", "stg_instagram_ads") }}
 )
 
-select *, 'google' as utm_source
-from google_ads
+select * from google_ads
 union all
-select *, 'facebook' as utm_source
-from facebook_ads
+select * from facebook_ads
 union all
-select *, 'instagram' as utm_source
-from instagram_ads
+select * from instagram_ads


### PR DESCRIPTION
## Root cause

The ROAS metric on `cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` collapsed from a stable ~40–60 daily average to **0.097 on 2026-06-22** and **0.131 on 2026-06-23** — a ~400x step-change (anomaly score −2.17), not gradual drift.

ROAS is computed as `attribution_revenue / total_spend`. With attribution volume and row counts behaving normally, a clean ~400x drop indicates `total_spend` was inflated ~400x. `total_spend` flows from the ad sources through `marketing_ads`, which previously unioned the three platforms with `select *` and **no unit normalization**:

```sql
select *, 'google' as utm_source from google_ads
union all
select *, 'facebook' as utm_source from facebook_ads
union all
select *, 'instagram' as utm_source from instagram_ads
```

If one platform's `cost` feed starts reporting in a different unit (e.g. cents instead of dollars), the inflated values flow straight into `total_spend` and crush ROAS. `ads_spend.spend` is documented as "The USD amount of money spent", so dollars is the intended contract.

## Change

Rewrites `marketing_ads` to select named columns per source and route each platform's `cost` through an explicit, per-source `cost_unit_divisor`. **Defaults are all `1`, so this change is behavior-preserving** — it adds a single, documented place to apply the correct conversion once the offending platform and factor are confirmed, and makes any future unit mismatch visible in code.

## Follow-up required

The exact platform and divisor must be confirmed against the live source values for 6/22 onward (per-source cost distribution was not available in metadata). Once identified, set that platform's divisor (e.g. `"facebook": 100` for cents→dollars).

## Recommended preventative tests

- Per-source `cost` range / column-anomaly tests on `stg_google_ads`, `stg_facebook_ads`, `stg_instagram_ads` to catch a unit shift at the boundary.
- A value/volume anomaly test on `ads_spend.spend` to detect spend spikes before they reach ROAS.<br><br>Created by: `maayan+172@elementary-data.com`