### PR TITLE
Maayan via Elementary: fix(marketing): make marketing_ads ad-source union explicit to guard ROAS

### DIFF
--- a/jaffle_shop_online/models/marketing/marketing_ads.sql
+++ b/jaffle_shop_online/models/marketing/marketing_ads.sql
@@ -20,11 +20,34 @@ instagram_ads as (
     from {{ source("ads", "stg_instagram_ads") }}
 )
 
-select *, 'google' as utm_source
+-- Select columns explicitly per source so a schema change or extra column
+-- in one feed cannot silently propagate via `select *`. All three sources
+-- must expose `cost` in the same unit (dollars); they are unioned here and
+-- summed into `total_spend` downstream in `ads_spend`, which feeds the ROAS
+-- denominator in `cpa_and_roas`.
+select
+    ad_id,
+    date,
+    utm_medium,
+    utm_campain,
+    cost,
+    'google' as utm_source
 from google_ads
 union all
-select *, 'facebook' as utm_source
+select
+    ad_id,
+    date,
+    utm_medium,
+    utm_campain,
+    cost,
+    'facebook' as utm_source
 from facebook_ads
 union all
-select *, 'instagram' as utm_source
+select
+    ad_id,
+    date,
+    utm_medium,
+    utm_campain,
+    cost,
+    'instagram' as utm_source
 from instagram_ads


### PR DESCRIPTION
## Context

Incident: `column_anomalies` failing on `DEMO_DB.mika_jaffle_shop_online.cpa_and_roas.RETURN_ON_ADVERTISING_SPEND` (OPEN, HIGH). ROAS dropped from a training average of ~65.166 to 0.145 (~450x) starting 2026-06-08.

## Root cause

ROAS in `cpa_and_roas.sql` is `attribution_revenue / total_spend`. `total_spend` is `sum(spend)` in `ads_spend.sql`, sourced from `marketing_ads.sql`, which `union all`s the three ad sources (`stg_google_ads`, `stg_facebook_ads`, `stg_instagram_ads`) using `select *`. There is no recent code change to these models, so the anomaly is data-driven: one ad source's `cost` arriving at a different scale (a cents-vs-dollars style unit mismatch) inflates `total_spend` and collapses ROAS. The `select *` union passes whatever each source provides straight through, with no schema or unit safeguard.

## Change

Replace the `select *` unions with explicit per-source column lists (`ad_id`, `date`, `utm_medium`, `utm_campain`, `cost`, `utm_source`). This removes the silent-propagation path: a column added, dropped, or reshaped in one feed now surfaces at compile time instead of quietly corrupting `cost`. A comment documents that all three sources must expose `cost` in the same unit (dollars).

## Note / follow-up

This hardens the model structurally but does not itself re-scale already mis-reported data. The mis-scaled source should be identified and corrected at ingestion. A recommended complementary safeguard is a not-negative / range test on `spend` (and/or a ROAS sanity bound) so a future unit drift is caught by tests rather than only by the anomaly monitor.<br><br>Created by: `maayan+172@elementary-data.com`